### PR TITLE
fix: podcast release dates showing as unknown on iPod

### DIFF
--- a/GUI/app.py
+++ b/GUI/app.py
@@ -742,7 +742,7 @@ class iTunesDBCache(QObject):
         from iTunesDB_Parser.parser import parse_itunesdb
         from iTunesDB_Shared.constants import (
             extract_datasets, extract_mhod_strings, extract_playlist_extras,
-            mac_to_unix_timestamp, filetype_to_string, sample_rate_to_hz,
+            filetype_to_string, sample_rate_to_hz,
         )
         if not itunesdb_path or not os.path.exists(itunesdb_path):
             return (None, device_path)
@@ -762,12 +762,6 @@ class iTunesDBCache(QObject):
                 sr = track.get("sample_rate_1")
                 if isinstance(sr, int) and sr > 65535:
                     track["sample_rate_1"] = sample_rate_to_hz(sr)
-                # Mac timestamps → Unix
-                for ts_key in ("date_added", "date_released", "last_modified",
-                               "last_played", "last_skipped"):
-                    val = track.get(ts_key, 0)
-                    if isinstance(val, int) and val > 0:
-                        track[ts_key] = mac_to_unix_timestamp(val)
 
             # Inline MHOD strings for albums
             for album in data.get("mhla", []):
@@ -788,11 +782,6 @@ class iTunesDBCache(QObject):
                         mhip_data = mhip.get("data", {}) if isinstance(mhip, dict) and "data" in mhip else mhip
                         items.append({"track_id": mhip_data.get("track_id", 0)})
                     pl["items"] = items
-                    # Mac timestamps → Unix
-                    for ts_key in ("timestamp", "timestamp_2"):
-                        val = pl.get(ts_key, 0)
-                        if isinstance(val, int) and val > 0:
-                            pl[ts_key] = mac_to_unix_timestamp(val)
 
             # Inline MHOD strings for artists (mhsd type 8)
             for artist in data.get("mhsd_type_8", []):

--- a/SyncEngine/sync_executor.py
+++ b/SyncEngine/sync_executor.py
@@ -1646,7 +1646,7 @@ class SyncExecutor:
         from iTunesDB_Parser.playcounts import parse_playcounts, merge_playcounts
         from iTunesDB_Shared.constants import (
             extract_datasets, extract_mhod_strings, extract_playlist_extras,
-            filetype_to_string, sample_rate_to_hz, mac_to_unix_timestamp,
+            filetype_to_string, sample_rate_to_hz,
         )
 
         empty = {"tracks": [], "playlists": [], "smart_playlists": []}
@@ -1669,10 +1669,6 @@ class SyncExecutor:
                     t["filetype"] = filetype_to_string(t["filetype"])
                 if "sample_rate_1" in t:
                     t["sample_rate_1"] = sample_rate_to_hz(t["sample_rate_1"])
-                for ts_key in ("date_added", "date_released", "last_modified",
-                               "last_played", "last_skipped"):
-                    if t.get(ts_key, 0) > 0:
-                        t[ts_key] = mac_to_unix_timestamp(t[ts_key])
 
             # ── Merge Play Counts file (iPod-generated deltas) ──────────
             pc_path = self.ipod_path / "iPod_Control" / "iTunes" / "Play Counts"
@@ -1696,9 +1692,6 @@ class SyncExecutor:
                     pl.update(extract_playlist_extras(mhod_children))
                     mhip_children = pl.pop("mhip_children", [])
                     pl["items"] = mhip_children
-                    for ts_key in ("timestamp", "timestamp_2"):
-                        if pl.get(ts_key, 0) > 0:
-                            pl[ts_key] = mac_to_unix_timestamp(pl[ts_key])
 
             # Dataset 2: regular + user playlists (mhlp)
             # libgpod prefers DS3 over DS2 and only reads ONE.  We prefer


### PR DESCRIPTION
## Summary

- Removes duplicate Mac-to-Unix epoch conversion that was corrupting all timestamp fields (date_added, date_released, last_modified, etc.) when reading back the existing iTunesDB
- The field parser's `read_transform` already handles the conversion, so the manual `mac_to_unix_timestamp()` calls in `_read_existing_database()` and the GUI's `_load_data()` were applying it a second time, subtracting ~66 years from every timestamp
- This caused podcast episodes to show "Unknown Release Date" and appear out of order on the iPod

## Test plan

- [x] Built macOS app with PyInstaller and tested on iPod Nano 3G
- [x] Synced podcast episodes and verified release dates now display correctly on the iPod
- [x] Episodes appear in chronological order in the iPod's podcast player

![IMG_0043](https://github.com/user-attachments/assets/28b8c47a-f707-4df5-8750-cd6f87e520bb)

Fixes #17