### PR TITLE
fix: render all pixmaps at native resolution on HiDPI/Retina displays

### DIFF
--- a/GUI/glyphs.py
+++ b/GUI/glyphs.py
@@ -77,11 +77,17 @@ def glyph_pixmap(name: str, size: int, color: str = "#ffffff") -> QPixmap | None
     renderer = QSvgRenderer(QByteArray(colored))
     if not renderer.isValid():
         return None
-    px = QPixmap(size, size)
+    # Render at physical pixel size for crisp output on HiDPI/Retina displays
+    from PyQt6.QtWidgets import QApplication
+    app = QApplication.instance()
+    dpr = app.primaryScreen().devicePixelRatio() if app and app.primaryScreen() else 1.0
+    phys = round(size * dpr)
+    px = QPixmap(phys, phys)
     px.fill(Qt.GlobalColor.transparent)
     painter = QPainter(px)
     renderer.render(painter)
     painter.end()
+    px.setDevicePixelRatio(dpr)
     return px
 
 

--- a/GUI/ipod_images.py
+++ b/GUI/ipod_images.py
@@ -23,6 +23,33 @@ _IMAGE_DIR = _PROJECT_ROOT / "assets" / "ipod_images"
 
 
 @lru_cache(maxsize=128)
+def _get_ipod_image_cached(
+    family: str,
+    generation: str,
+    size: int,
+    color: str,
+    dpr: float,
+) -> QPixmap:
+    """Internal cached loader — includes dpr in cache key."""
+    filename = resolve_image_filename(family, generation, color)
+    path = _IMAGE_DIR / filename
+    if not path.exists():
+        path = _IMAGE_DIR / GENERIC_IMAGE
+
+    pixmap = QPixmap(str(path))
+    if pixmap.isNull():
+        return QPixmap()
+
+    phys = round(size * dpr)
+    pixmap = pixmap.scaled(
+        phys, phys,
+        Qt.AspectRatioMode.KeepAspectRatio,
+        Qt.TransformationMode.SmoothTransformation,
+    )
+    pixmap.setDevicePixelRatio(dpr)
+    return pixmap
+
+
 def get_ipod_image(
     family: str,
     generation: str,
@@ -45,19 +72,9 @@ def get_ipod_image(
         color:      e.g. "Black", "Silver", "Blue" (optional)
 
     Returns:
-        QPixmap scaled to fit within sizexsize.
+        QPixmap scaled to fit within sizexsize (HiDPI-aware).
     """
-    filename = resolve_image_filename(family, generation, color)
-    path = _IMAGE_DIR / filename
-    if not path.exists():
-        path = _IMAGE_DIR / GENERIC_IMAGE
-
-    pixmap = QPixmap(str(path))
-    if pixmap.isNull():
-        return QPixmap()  # Return empty pixmap if loading failed
-
-    return pixmap.scaled(
-        size, size,
-        Qt.AspectRatioMode.KeepAspectRatio,
-        Qt.TransformationMode.SmoothTransformation,
-    )
+    from PyQt6.QtWidgets import QApplication
+    app = QApplication.instance()
+    dpr = app.primaryScreen().devicePixelRatio() if app and app.primaryScreen() else 1.0
+    return _get_ipod_image_cached(family, generation, size, color, dpr)

--- a/GUI/widgets/MBGridViewItem.py
+++ b/GUI/widgets/MBGridViewItem.py
@@ -190,11 +190,14 @@ class MusicBrowserGridItem(QFrame):
             # Copy the QImage to own the data (prevents crash when data goes out of scope)
             qimage = qimage.copy()
             pixmap = QPixmap.fromImage(qimage)
+            dpr = self.img_label.devicePixelRatio()
+            phys = round(Metrics.GRID_ART_SIZE * dpr)
             pixmap = pixmap.scaled(
-                Metrics.GRID_ART_SIZE, Metrics.GRID_ART_SIZE,
+                phys, phys,
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation
             )
+            pixmap.setDevicePixelRatio(dpr)
             self.img_label.setPixmap(pixmap)
             self.img_label.setStyleSheet(f"""
                 border: none;

--- a/GUI/widgets/MBListView.py
+++ b/GUI/widgets/MBListView.py
@@ -1054,11 +1054,14 @@ class MusicBrowserList(QFrame):
                     continue
                 w, h, rgba = data
                 qimg = QImage(rgba, w, h, QImage.Format.Format_RGBA8888).copy()
+                dpr = self.table.devicePixelRatio()
+                phys = round(ART_THUMB_SIZE * dpr)
                 pixmap = QPixmap.fromImage(qimg).scaled(
-                    ART_THUMB_SIZE, ART_THUMB_SIZE,
+                    phys, phys,
                     Qt.AspectRatioMode.KeepAspectRatio,
                     Qt.TransformationMode.SmoothTransformation,
                 )
+                pixmap.setDevicePixelRatio(dpr)
                 self._art_cache[link] = pixmap
 
             # Backfill rows

--- a/GUI/widgets/podcastBrowser.py
+++ b/GUI/widgets/podcastBrowser.py
@@ -1115,11 +1115,14 @@ class PodcastBrowser(QFrame):
     def _load_feed_artwork(self, url: str) -> None:
         """Load feed artwork for the header panel in background."""
         if url in _artwork_cache:
+            dpr = self._feed_art.devicePixelRatio()
+            phys = round(scaled(44) * dpr)
             pm = _artwork_cache[url].scaled(
-                scaled(44), scaled(44),
+                phys, phys,
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation,
             )
+            pm.setDevicePixelRatio(dpr)
             self._feed_art.setPixmap(pm)
             self._feed_art.setText("")
             return
@@ -1152,11 +1155,14 @@ class PodcastBrowser(QFrame):
 
         # Update header art if still showing the same feed
         if self._selected_feed and self._selected_feed.artwork_url == url:
+            dpr = self._feed_art.devicePixelRatio()
+            phys = round(scaled(44) * dpr)
             pm = full_pm.scaled(
-                scaled(44), scaled(44),
+                phys, phys,
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation,
             )
+            pm.setDevicePixelRatio(dpr)
             self._feed_art.setPixmap(pm)
             self._feed_art.setText("")
 
@@ -1196,11 +1202,16 @@ class PodcastBrowser(QFrame):
         """Set the icon for all feed list items whose artwork URL matches."""
         if not self._store:
             return
+        from PyQt6.QtWidgets import QApplication
+        app = QApplication.instance()
+        dpr = app.primaryScreen().devicePixelRatio() if app and app.primaryScreen() else 1.0
+        phys = round(scaled(36) * dpr)
         icon_pm = full_pm.scaled(
-            scaled(36), scaled(36),
+            phys, phys,
             Qt.AspectRatioMode.KeepAspectRatio,
             Qt.TransformationMode.SmoothTransformation,
         )
+        icon_pm.setDevicePixelRatio(dpr)
         icon = QIcon(icon_pm)
         feeds = self._store.get_feeds()
         for i, feed in enumerate(feeds):

--- a/GUI/widgets/podcastSearchDialog.py
+++ b/GUI/widgets/podcastSearchDialog.py
@@ -338,10 +338,13 @@ class _SearchResultCard(QFrame):
     def _on_artwork_loaded(self, data: bytes):
         img = QImage()
         if img.loadFromData(data):
+            dpr = self._art_label.devicePixelRatio()
+            phys = round(scaled(56) * dpr)
             pm = QPixmap.fromImage(img).scaled(
-                scaled(56), scaled(56),
+                phys, phys,
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation,
             )
+            pm.setDevicePixelRatio(dpr)
             self._art_label.setPixmap(pm)
             self._art_label.setText("")


### PR DESCRIPTION
## Summary
- All manually-constructed `QPixmap` objects now render at `devicePixelRatio()` physical pixels instead of logical pixels, fixing blur on HiDPI/Retina displays (e.g. Apple Studio Display at 2x)
- Affected components: album art grid, track list thumbnails, SVG glyph icons, iPod product photos, podcast artwork
- The fix applies the same pattern everywhere: scale to `size * dpr` physical pixels, then call `pixmap.setDevicePixelRatio(dpr)`

## Test plan
- [ ] Verify album art in grid view is crisp on a Retina display
- [x] Verify track list thumbnails are sharp
- [x] Verify sidebar icons (SVG glyphs) have crisp edges
- [x] Verify iPod product photo in sidebar is not blurry
- [ ] Verify podcast artwork (feed list, header, search results) is sharp
- [ ] Verify no regression on non-HiDPI (1x) displays

Closes #21