### PR TITLE
Fix TypeError: object of type 'bool' has no len() when reading M4A compilation/podcast files

### DIFF
--- a/SyncEngine/pc_library.py
+++ b/SyncEngine/pc_library.py
@@ -1192,8 +1192,11 @@ class PCLibrary:
                     metadata[meta_key] = str(val[0])
 
             # Compilation flag
+            # mutagen stores cpil as a scalar bool (single=True), not a list
             cpil = audio.tags.get("cpil")
-            if cpil and len(cpil) > 0:
+            if isinstance(cpil, bool):
+                metadata["compilation"] = cpil
+            elif cpil and len(cpil) > 0:
                 metadata["compilation"] = bool(cpil[0])
 
             # Composer
@@ -1265,8 +1268,12 @@ class PCLibrary:
                     pass
 
             # pcst: Podcast flag atom (boolean, present = podcast)
+            # mutagen stores pcst as a scalar bool (single=True), not a list
             pcst = audio.tags.get("pcst")
-            if pcst and len(pcst) > 0:
+            if isinstance(pcst, bool):
+                if pcst:
+                    metadata["is_podcast"] = True
+            elif pcst and len(pcst) > 0:
                 try:
                     if int(pcst[0]):
                         metadata["is_podcast"] = True


### PR DESCRIPTION
Certain M4A files (e.g. compilations) were silently skipped during library scanning with `Failed to read ...: object of type 'bool' has no len()`.

## Root Cause

mutagen stores the `cpil` (compilation) and `pcst` (podcast) MP4 atoms as **scalar `bool`** values via `single=True` in its internal `__parse_bool` — not as lists. The existing code assumed list form and called `len()` unconditionally:

```python
# cpil = True  →  len(True) raises TypeError
if cpil and len(cpil) > 0:
    metadata["compilation"] = bool(cpil[0])
```

The `TypeError` propagated to the outer `try/except` in `scan_library`, causing the file to be skipped entirely.

## Fix

Guard with `isinstance(..., bool)` before calling `len()`, using the scalar directly:

```python
if isinstance(cpil, bool):
    metadata["compilation"] = cpil
elif cpil and len(cpil) > 0:
    metadata["compilation"] = bool(cpil[0])
```

Same pattern applied to `pcst`. The `elif` branch preserves backward compatibility if the value ever arrives as a list.

--> Done with Copilot coding agent