### PR TITLE
Add remove_playlist_names to SyncExecutor and fix mhip playlist item parsing 

### DIFF
--- a/SyncEngine/sync_executor.py
+++ b/SyncEngine/sync_executor.py
@@ -661,8 +661,10 @@ class SyncExecutor:
                             break
                 if not replaced:
                     ctx.existing_playlists_raw.append(upl)
-            logger.info("Merged user playlist '%s' (id=0x%X, new=%s)",
-                        upl.get("Title", "?"), pid, is_new)
+            logger.info("Merged user playlist '%s' (id=%s, new=%s)",
+                        upl.get("Title", "?"),
+                        ("0x%X" % pid) if pid is not None else "new",
+                        is_new)
             ctx.progress("playlists", idx + 1, len(user_pls),
                          message=f"Merged playlist: {upl.get('Title', '?')}")
 


### PR DESCRIPTION
Been using iOpenPod in my app and it's been really good so far. Ran across a few minor playlist bugs, so here are two independent fixes                                                                      
                                                                                                                       
~~1. remove_playlist_names parameter (new feature)~~
                                                                                                             
~~SyncExecutor.execute() now accepts remove_playlist_names: list[str]. Before merging user-created playlists, any existing on-device playlist whose name matches (case-insensitive) is removed. This makes it possible for callers to cleanly replace or delete playlists by name without needing to manipulate the raw playlist data themselves.~~

~~2. mhip_children playlist item parsing (bug fix)~~                                                                                              

  ~~When reading playlists back from the iTunesDB, mhip_children entries were being stored as raw dicts with a nested    
  "data" key ({"data": {"track_id": N, ...}}). Downstream code that builds the write-back structure expected flat
  {"track_id": N} dicts, so any sync that read existing playlists and wrote them back would lose all track references. 
  The fix normalises each item at parse time.~~                                                                      

  3. Logger crash on new playlists (bug fix)                                                                           
   
  "id=0x%X" % pid raises TypeError when pid is None, which happens for newly created playlists that haven't been       
  assigned an ID yet. Fixed to emit "new" in that case. 