### PR TITLE
Add an AUR package for Arch-based linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Grab the latest release for your platform. No Python required, no setup wizards,
 | **Windows** | `iOpenPod-windows.zip` | Extract, and run `iOpenPod.exe` |
 | **macOS** | `iOpenPod-macos.tar.gz` | Extract, and run `iOpenPod.app`, you will need to allow the unknown developer in System Settings. |
 | **Linux (All distros)** | `iOpenPod-linux.tar.gz` | Extract, and run `./iOpenPod` |
-| **Linux (Arch-based)** | `iopenpod`<sup>AUR</sup> | Available in the AUR |
+| **Linux (Arch-based)** | [`iopenpod`](https://aur.archlinux.org/packages/iopenpod)<sup>AUR</sup> | Available in the AUR |
 
 Once installed, iOpenPod can check for updates automatically and can update itself right from the app. (Except when installed from AUR.)
 


### PR DESCRIPTION
I made a package for iOpenPod on the Arch User Repository mainly for easier installation and adding a desktop entry on Arch-based distros. Here is a link to the package - https://aur.archlinux.org/packages/iopenpod. I intend to keep up with the updates because i use it often for my iPod.