### PR TITLE
fix: crash on Select Device when non-iPod Apple USB devices are present

### DIFF
--- a/ipod_device/scanner.py
+++ b/ipod_device/scanner.py
@@ -301,6 +301,49 @@ def _clear_macos_usb_cache() -> None:
         _macos_serial_to_dev = None
 
 
+def _parse_macos_ioreg_bsd_serials(text: str) -> dict[str, str]:
+    """Pair iPod BSD whole-disk names with their owning USB serial numbers.
+
+    The text ioreg output for iPod nodes looks like::
+
+        +-o iPod@01130000  <class IOUSBHostDevice, ...>
+          |   "USB Serial Number" = "000A270018A1F847"
+          |   "idProduct" = 4704
+          ...
+          +-o Apple iPod Media  <class IOMedia, ...>
+          |   "BSD Name" = "disk4"
+
+    We track the most recent ``"USB Serial Number"`` seen.  When we hit an
+    ``"Apple iPod Media"`` entry followed by a ``"BSD Name"``, we pair the
+    disk with the remembered serial — the iPod media node is a descendant
+    of its owning USB device, so the iPod's serial is the latest one seen.
+
+    Only iPod media disks are paired; serials of unrelated Apple devices
+    (keyboards, AirPods receivers, iPhones, hubs) are ignored.
+    """
+    import re as _re
+
+    bsd_map: dict[str, str] = {}
+    current_serial: str = ""
+    pending_serial: str = ""
+    for line in text.splitlines():
+        m_serial = _re.search(r'"USB Serial Number"\s*=\s*"([^"]+)"', line)
+        if m_serial:
+            current_serial = (
+                m_serial.group(1).replace(" ", "").strip().upper()
+            )
+            continue
+        if "Apple iPod Media" in line:
+            pending_serial = current_serial
+            continue
+        # BSD Name on IOMedia child
+        m = _re.search(r'"BSD Name"\s*=\s*"(disk\d+)"', line)
+        if m and pending_serial:
+            bsd_map[m.group(1)] = pending_serial
+            pending_serial = ""
+    return bsd_map
+
+
 def _build_macos_usb_cache() -> None:
     """Build both caches from ioreg in one shot.
 
@@ -309,13 +352,10 @@ def _build_macos_usb_cache() -> None:
     global _macos_bsd_to_serial, _macos_serial_to_dev
 
     import plistlib
-    import re as _re
     import subprocess
 
     bsd_map: dict[str, str] = {}
     dev_map: dict[str, dict] = {}
-    ordered_serials: list[str] = []
-    ordered_bsd_disks: list[str] = []
 
     def _collect_usb_devices(node: object) -> None:
         if isinstance(node, list):
@@ -332,25 +372,12 @@ def _build_macos_usb_cache() -> None:
             )
             key = str(serial).replace(" ", "").strip().upper()
             if key:
-                if key not in dev_map:
-                    ordered_serials.append(key)
                 dev_map[key] = node
 
         for child in node.get("IORegistryEntryChildren") or []:
             _collect_usb_devices(child)
 
     # ── 1. Text parse: map BSD whole-disk → USB serial ─────────────────
-    #
-    # The text ioreg output for iPod nodes looks like:
-    #   +-o iPod@01130000  <class IOUSBHostDevice, ...>
-    #     |   "USB Serial Number" = "000A270018A1F847"
-    #     |   "idProduct" = 4704
-    #     ...
-    #     +-o Apple iPod Media  <class IOMedia, ...>
-    #     |   "BSD Name" = "disk4"
-    #
-    # We track the current USB serial as we scan lines.  When we hit a
-    # "BSD Name" at a deeper indent, we know which USB device owns it.
     try:
         proc = subprocess.run(
             ["ioreg", "-r", "-c", "IOMedia"],
@@ -358,16 +385,7 @@ def _build_macos_usb_cache() -> None:
             encoding="utf-8", errors="replace", timeout=8,
         )
         if proc.returncode == 0 and proc.stdout:
-            pending_serial: str = ""
-            for line in proc.stdout.splitlines():
-                if "Apple iPod Media" in line:
-                    pending_serial = "media"
-                    continue
-                # BSD Name on IOMedia child
-                m = _re.search(r'"BSD Name"\s*=\s*"(disk\d+)"', line)
-                if m and pending_serial:
-                    ordered_bsd_disks.append(m.group(1))
-                    pending_serial = ""
+            bsd_map = _parse_macos_ioreg_bsd_serials(proc.stdout)
     except subprocess.TimeoutExpired:
         logger.warning("macOS: ioreg text parse timed out")
     except Exception as e:
@@ -384,9 +402,6 @@ def _build_macos_usb_cache() -> None:
             _collect_usb_devices(parsed)
     except Exception as e:
         logger.debug("ioreg plist query failed: %s", e)
-
-    for disk_name, serial_key in zip(ordered_bsd_disks, ordered_serials, strict=True):
-        bsd_map[disk_name] = serial_key
 
     if bsd_map:
         logger.debug("macOS: BSD→serial map: %s", bsd_map)

--- a/tests/test_macos_scanner_parser.py
+++ b/tests/test_macos_scanner_parser.py
@@ -1,0 +1,111 @@
+"""Unit tests for the macOS ioreg → (BSD disk, USB serial) parser.
+
+These cover the bug that crashed device identification with
+``ValueError: zip() argument 2 is longer than argument 1`` whenever the
+Mac had any non-iPod Apple USB device on the bus (keyboard, AirPods
+receiver, hub, iPhone).  The parser now extracts the iPod's own serial
+inline from the text ioreg, so unrelated Apple devices never end up
+paired with an iPod's BSD whole-disk name.
+"""
+
+from __future__ import annotations
+
+from ipod_device.scanner import _parse_macos_ioreg_bsd_serials
+
+_SINGLE_IPOD = """\
++-o iPod@01130000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "000A270018A1F847"
+  |   "idProduct" = 4704
+  +-o IOUSBMassStorageDriver  <class IOUSBMassStorageDriver, ...>
+    +-o IOUSBMassStorageInterfaceNub  <class IOSCSIPeripheralDeviceType00, ...>
+      +-o Apple iPod Media  <class IOMedia, ...>
+      |   "BSD Name" = "disk4"
+"""
+
+
+_SINGLE_IPOD_WITH_OTHER_APPLE_DEVICES = """\
++-o AppleUSBKeyboard@14100000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "KBD-ABCDEF"
+  |   "idProduct" = 555
++-o iPod@01130000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "000A270018A1F847"
+  |   "idProduct" = 4704
+  +-o IOUSBMassStorageDriver  <class IOUSBMassStorageDriver, ...>
+    +-o IOUSBMassStorageInterfaceNub  <class IOSCSIPeripheralDeviceType00, ...>
+      +-o Apple iPod Media  <class IOMedia, ...>
+      |   "BSD Name" = "disk4"
++-o AppleAirPodsReceiver@14200000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "AIRPODS-XYZ"
+  |   "idProduct" = 999
+"""
+
+
+_TWO_IPODS_VIA_HUB = """\
++-o AppleUSBHub@14000000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "HUB-001"
+  |   "idProduct" = 100
+  +-o iPod@14100000  <class IOUSBHostDevice, ...>
+  |   |   "USB Serial Number" = "AAA111"
+  |   |   "idProduct" = 4704
+  |   +-o IOUSBMassStorageDriver  <class IOUSBMassStorageDriver, ...>
+  |     +-o IOUSBMassStorageInterfaceNub  <class IOSCSIPeripheralDeviceType00, ...>
+  |       +-o Apple iPod Media  <class IOMedia, ...>
+  |       |   "BSD Name" = "disk4"
+  +-o iPod@14200000  <class IOUSBHostDevice, ...>
+    |   "USB Serial Number" = "BBB222"
+    |   "idProduct" = 4704
+    +-o IOUSBMassStorageDriver  <class IOUSBMassStorageDriver, ...>
+      +-o IOUSBMassStorageInterfaceNub  <class IOSCSIPeripheralDeviceType00, ...>
+        +-o Apple iPod Media  <class IOMedia, ...>
+        |   "BSD Name" = "disk6"
+"""
+
+
+def test_parser_pairs_single_ipod_with_its_serial() -> None:
+    assert _parse_macos_ioreg_bsd_serials(_SINGLE_IPOD) == {
+        "disk4": "000A270018A1F847",
+    }
+
+
+def test_parser_ignores_unrelated_apple_devices() -> None:
+    """Regression for the ValueError("zip()...") crash from issue notes.
+
+    With a keyboard and AirPods receiver on the bus, the previous
+    implementation built two parallel lists and zipped them with
+    strict=True — three Apple serials vs one iPod disk crashed.  The
+    inline serial parse pairs only the iPod disk and drops the rest.
+    """
+    assert _parse_macos_ioreg_bsd_serials(
+        _SINGLE_IPOD_WITH_OTHER_APPLE_DEVICES
+    ) == {"disk4": "000A270018A1F847"}
+
+
+def test_parser_pairs_two_ipods_behind_a_hub() -> None:
+    """Each iPod's media disk pairs with its own serial, not the hub's."""
+    assert _parse_macos_ioreg_bsd_serials(_TWO_IPODS_VIA_HUB) == {
+        "disk4": "AAA111",
+        "disk6": "BBB222",
+    }
+
+
+def test_parser_returns_empty_when_no_ipods_present() -> None:
+    only_keyboard = """\
++-o AppleUSBKeyboard@14100000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "KBD-ABCDEF"
+  |   "idProduct" = 555
+"""
+    assert _parse_macos_ioreg_bsd_serials(only_keyboard) == {}
+
+
+def test_parser_normalises_serial_whitespace_and_case() -> None:
+    """Serials with embedded spaces/lowercase are normalised the same way
+    the plist collector does, so both maps can be cross-referenced.
+    """
+    sample = """\
++-o iPod@01130000  <class IOUSBHostDevice, ...>
+  |   "USB Serial Number" = "a b c 123 def"
+  +-o IOUSBMassStorageDriver  <class IOUSBMassStorageDriver, ...>
+    +-o Apple iPod Media  <class IOMedia, ...>
+    |   "BSD Name" = "disk2"
+"""
+    assert _parse_macos_ioreg_bsd_serials(sample) == {"disk2": "ABC123DEF"}


### PR DESCRIPTION
## Summary

- Fixes `ValueError: zip() argument 2 is longer than argument 1` in `_build_macos_usb_cache` that crashes device identification whenever a non-iPod Apple USB device is also on the bus (Apple keyboards, AirPods receivers, hubs, iPhones).
- The previous code built two lists in different ioreg passes and zipped them with `strict=True`: `ordered_bsd_disks` from the text pass (only "Apple iPod Media" entries) and `ordered_serials` from the plist pass (every `idVendor=0x05AC` device). These describe different sets, so any extra Apple peripheral makes the zip raise.
- Extracts a pure helper `_parse_macos_ioreg_bsd_serials(text)` that scans the text ioreg once, tracking the most recent "USB Serial Number" seen, and pairs each "Apple iPod Media" disk with its own owning device's serial. The plist pass still builds `dev_map` keyed by serial; downstream consumers are unchanged.

## Test plan

- [x] New unit tests in `tests/test_macos_scanner_parser.py`: single iPod, iPod with unrelated Apple devices (the bug case), two iPods behind a hub, no iPods present, serial whitespace and case normalisation
- [x] Live-tested against a Mac with several Apple USB devices on the bus. Pre-fix crashed on Select Device; post-fix identifies the iPod cleanly
- [x] Ruff clean