### PR TITLE
Feature: show sync pipeline as left-side checklist during sync

### DIFF
--- a/GUI/widgets/syncReview.py
+++ b/GUI/widgets/syncReview.py
@@ -62,6 +62,7 @@ from ..glyphs import glyph_icon, glyph_pixmap
 from ..styles import FONT_FAMILY, Colors, Metrics, accent_btn_css, btn_css, make_scroll_area
 from .formatters import format_duration_mmss as _format_duration
 from .formatters import format_size as _format_size
+from .syncStagesPanel import DEFAULT_PIPELINE, SyncStagesPanel
 
 logger = logging.getLogger(__name__)
 
@@ -1258,16 +1259,32 @@ class SyncReviewWidget(QWidget):
         self.stack = QStackedWidget(self)
         layout.addWidget(self.stack, 1)
 
-        # Loading / executing state
+        # Loading / executing state.  The outer layout is horizontal so we
+        # can render the sync-stages checklist on the left of the view; the
+        # centered headline + progress bar lives in a column on the
+        # right.  The panel is hidden during scan/diff (it only describes
+        # the executor's pipeline) and shown when ``show_executing`` runs.
         loading_widget = QWidget(self.stack)
-        loading_layout = QVBoxLayout(loading_widget)
+        loading_outer = QHBoxLayout(loading_widget)
+        loading_outer.setContentsMargins(0, 0, 0, 0)
+        loading_outer.setSpacing(0)
+
+        self._stages_panel = SyncStagesPanel(DEFAULT_PIPELINE, loading_widget)
+        self._stages_panel.setMinimumWidth(260)
+        self._stages_panel.setMaximumWidth(300)
+        self._stages_panel.setVisible(False)
+        loading_outer.addWidget(self._stages_panel)
+
+        loading_center = QWidget(loading_widget)
+        loading_layout = QVBoxLayout(loading_center)
         loading_layout.setContentsMargins(24, 0, 24, 0)
         loading_layout.setSpacing(0)
+        loading_outer.addWidget(loading_center, 1)
 
         loading_layout.addStretch(3)
 
         # Stage headline
-        self.loading_label = QLabel("Scanning library...", loading_widget)
+        self.loading_label = QLabel("Scanning library...", loading_center)
         self.loading_label.setStyleSheet(
             f"color: {Colors.TEXT_PRIMARY}; font-size: {Metrics.FONT_HERO}px;"
             f" font-weight: 500;"
@@ -1278,7 +1295,7 @@ class SyncReviewWidget(QWidget):
         loading_layout.addSpacing(16)
 
         # Progress bar
-        self.progress_bar = QProgressBar(loading_widget)
+        self.progress_bar = QProgressBar(loading_center)
         self.progress_bar.setFixedWidth(360)
         self.progress_bar.setTextVisible(False)
         self.progress_bar.setStyleSheet(f"""
@@ -1298,7 +1315,7 @@ class SyncReviewWidget(QWidget):
         loading_layout.addSpacing(10)
 
         # ETA / counter
-        self.eta_label = QLabel("", loading_widget)
+        self.eta_label = QLabel("", loading_center)
         self.eta_label.setStyleSheet(
             f"color: {Colors.TEXT_TERTIARY}; font-size: {Metrics.FONT_MD}px;"
         )
@@ -1309,7 +1326,7 @@ class SyncReviewWidget(QWidget):
 
         # Detail — current item / worker lines.
         # Bounded size so a burst of active workers cannot grow the window.
-        self.progress_detail = QLabel("", loading_widget)
+        self.progress_detail = QLabel("", loading_center)
         self.progress_detail.setStyleSheet(
             f"color: {Colors.TEXT_TERTIARY}; font-size: {Metrics.FONT_LG}px;"
         )
@@ -1324,7 +1341,7 @@ class SyncReviewWidget(QWidget):
         self._backup_hint = QLabel(
             "Pre-sync backups are enabled. "
             "You can turn this off in Settings \u2192 Backups.",
-            loading_widget,
+            loading_center,
         )
         self._backup_hint.setStyleSheet(
             f"color: {Colors.TEXT_TERTIARY}; font-size: {Metrics.FONT_SM}px;"
@@ -1676,6 +1693,7 @@ class SyncReviewWidget(QWidget):
         "scan": "Scanning libraries",
         "scan_pc": "Scanning PC library",
         "scan_ipod": "Scanning iPod library",
+        "scan_playlists": "Scanning playlist files",
         "load_mapping": "Loading iPod mapping",
         "integrity": "Checking iPod integrity",
         "fingerprint": "Computing fingerprints",
@@ -1808,6 +1826,7 @@ class SyncReviewWidget(QWidget):
     def show_loading(self):
         """Show loading state."""
         self.stack.setCurrentIndex(0)
+        self._stages_panel.setVisible(False)
         self.loading_label.setText("Scanning library...")
         self.progress_bar.setRange(0, 0)  # Indeterminate
         self.eta_label.setText("")
@@ -1821,6 +1840,7 @@ class SyncReviewWidget(QWidget):
         """Show the Back Sync progress state."""
         self._cancelled = False
         self.stack.setCurrentIndex(0)
+        self._stages_panel.setVisible(False)
         self.loading_label.setText("Preparing Back Sync")
         self.progress_bar.setRange(0, 0)
         self.eta_label.setText("")
@@ -2542,6 +2562,9 @@ class SyncReviewWidget(QWidget):
         self._completed_stages = []
         self._current_exec_stage = ""
         self._eta_tracker.start()
+        # Reset and reveal the stages checklist on the left
+        self._stages_panel.reset_for_pipeline(DEFAULT_PIPELINE)
+        self._stages_panel.setVisible(True)
         self.stack.setCurrentIndex(0)  # Loading view
         self.loading_label.setText("Syncing")
         self.progress_detail.setText("")
@@ -2620,6 +2643,9 @@ class SyncReviewWidget(QWidget):
             if self._current_exec_stage:
                 self._completed_stages.append(self._friendly_stage(self._current_exec_stage))
             self._current_exec_stage = stage
+
+        # Forward every stage event to the left-rail checklist
+        self._stages_panel.notify_stage(stage)
 
         # During the backup stage, repurpose the footer cancel as "Skip"
         is_backup = (stage == "backup")
@@ -2716,6 +2742,8 @@ class SyncReviewWidget(QWidget):
         self.result_details.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
 
         success = getattr(result, 'success', True)
+        # End the checklist on the side, marking any todo rows as ok or failed depending on success
+        self._stages_panel.end_of_sync(failed=not success)
         errors = getattr(result, 'errors', [])
         partial_save = getattr(result, 'partial_save', False)
 
@@ -3054,6 +3082,7 @@ class SyncReviewWidget(QWidget):
 
     def show_error(self, message: str):
         """Show error message."""
+        self._stages_panel.end_of_sync(failed=True)
         QMessageBox.critical(self, "Sync Error", message)
         self.stack.setCurrentIndex(2)
         self.summary_label.setText("Error during scan")

--- a/GUI/widgets/syncStagesPanel.py
+++ b/GUI/widgets/syncStagesPanel.py
@@ -1,0 +1,374 @@
+"""Sync stages panel — left-hand-side checklist of sync pipeline steps.
+
+Each time we sync an iPod, we go through a set of phases to update the iPod (and back-sync ratings).
+
+This panel is used to show a list of which stage we are up to in the sync process.
+
+The goal of this is so that we can have a UI that looks like
+
+
++-------------------------------------------+
+| 1. Stage 1                                |
+| 2. Stage 2           [Stage Title Area]   |
+| 3. Stage 3               [Progress]       |
+| ...                                       |
++-------------------------------------------+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..styles import FONT_FAMILY, Colors, Metrics
+
+# ── Pure data model ─────────────────────────────────────────────────────
+
+
+class StageStatus(StrEnum):
+    """Per-stage display state in the checklist."""
+
+    PENDING = "pending"  # haven't reached this stage yet
+    CURRENT = "current"  # actively running right now
+    DONE = "done"  # completed successfully
+    SKIPPED = "skipped"  # the executor moved past without firing this stage
+    FAILED = "failed"  # the sync ended in failure while this stage was active
+
+
+@dataclass(frozen=True)
+class SyncStage:
+    """One row in the checklist.
+
+    *aliases* are the stage IDs the executor may emit while this checklist
+    row should be shown as CURRENT.  For example, the executor distinguishes
+    ``scrobble_listenbrainz`` and ``scrobble_lastfm`` but the user just sees
+    a single "Scrobble plays" row that stays active across both.
+    """
+
+    stage_id: str
+    label: str
+    aliases: frozenset[str] = field(default_factory=frozenset)
+
+    def matches(self, stage: str) -> bool:
+        return stage == self.stage_id or stage in self.aliases
+
+
+# Canonical full-sync pipeline, in the order the executor runs the phases.
+# Stages without an entry here are silently ignored by the state machine.
+# e.g. ``transcode``, which is a sub-stage of ``add``
+DEFAULT_PIPELINE: tuple[SyncStage, ...] = (
+    #         Internal ID, User Title, alias internal names
+    SyncStage("backup", "Pre-sync backup", frozenset({"backup"})),
+    SyncStage(
+        "remove",
+        "Remove obsolete tracks",
+        frozenset({"remove", "remove_chapter"}),
+    ),
+    SyncStage("update_file", "Re-sync changed files", frozenset({"update_file"})),
+    SyncStage("update_metadata", "Update metadata", frozenset({"update_metadata"})),
+    SyncStage("podcast_download", "Download podcasts", frozenset({"podcast_download"})),
+    SyncStage("add", "Copy new tracks", frozenset({"add"})),
+    SyncStage("replace_remove", "Clean up replaced tracks", frozenset({"replace_remove"})),
+    SyncStage("sound_check", "Compute Sound Check", frozenset({"sound_check"})),
+    SyncStage(
+        "playcount",
+        "Sync play counts & ratings",
+        frozenset({"sync_playcount", "sync_rating"}),
+    ),
+    SyncStage(
+        "scrobble",
+        "Scrobble plays",
+        frozenset({"scrobble", "scrobble_listenbrainz", "scrobble_lastfm"}),
+    ),
+    SyncStage(
+        "write_database",
+        "Write iPod database",
+        frozenset({"write_database", "playlists"}),
+    ),
+    SyncStage("backpatch", "Record source file identities", frozenset({"backpatch"})),
+    SyncStage(
+        "photo",
+        "Sync photos",
+        frozenset({"photo_prepare", "photo_write", "photo_compact", "scan_photos"}),
+    ),
+)
+
+
+def _index_for_stage(pipeline: Sequence[SyncStage], stage: str) -> int | None:
+    """Return the pipeline index whose row this raw stage belongs to."""
+    for idx, step in enumerate(pipeline):
+        if step.matches(stage):
+            return idx
+    return None
+
+
+def init_states(pipeline: Sequence[SyncStage]) -> dict[str, StageStatus]:
+    """Build a fresh PENDING state map keyed by ``stage_id``."""
+    return {step.stage_id: StageStatus.PENDING for step in pipeline}
+
+
+def apply_stage_event(
+    pipeline: Sequence[SyncStage],
+    states: Mapping[str, StageStatus],
+    active: str | None,
+    stage: str,
+) -> tuple[dict[str, StageStatus], str | None]:
+    """Transition the checklist in response to one executor stage event.
+
+    Returns ``(new_states, new_active)``.  Inputs are not mutated.
+
+    Rules:
+      * If ``stage`` doesn't map to any pipeline row, no-op (caller will
+        keep the current state — useful for sub-stages like ``transcode``).
+      * If the matched row is already the active one, no-op.
+      * Otherwise:
+          - the previous active row (if any) becomes ``DONE``,
+          - any still-``PENDING`` rows strictly between the previous and
+            new positions become ``SKIPPED`` (the executor passed them by
+            without firing them, so they had no work),
+          - the new row becomes ``CURRENT``.
+    """
+    new_idx = _index_for_stage(pipeline, stage)
+    if new_idx is None:
+        return dict(states), active
+
+    new_step_id = pipeline[new_idx].stage_id
+    if active == new_step_id:
+        return dict(states), active
+
+    new_states = dict(states)
+    prev_idx: int | None = None
+    if active is not None:
+        prev_idx = _index_for_stage(pipeline, active)
+        if prev_idx is not None:
+            new_states[pipeline[prev_idx].stage_id] = StageStatus.DONE
+
+    # Steps strictly between the previous and new position get SKIPPED.
+    # Forward jumps only — if the executor ever emitted an earlier stage
+    # after a later one (it doesn't today) we'd just retread that row.
+    if prev_idx is None or new_idx > prev_idx:
+        start = (prev_idx + 1) if prev_idx is not None else 0
+        for between_idx in range(start, new_idx):
+            row_id = pipeline[between_idx].stage_id
+            if new_states.get(row_id) == StageStatus.PENDING:
+                new_states[row_id] = StageStatus.SKIPPED
+
+    new_states[new_step_id] = StageStatus.CURRENT
+    return new_states, new_step_id
+
+
+def finalize_states_for_end_of_sync(
+    pipeline: Sequence[SyncStage],
+    states: Mapping[str, StageStatus],
+    active: str | None,
+    *,
+    failed: bool = False,
+) -> dict[str, StageStatus]:
+    """End-of-sync cleanup.
+
+    The currently-active row is marked ``DONE`` (or ``FAILED`` if the sync
+    finished unsuccessfully while it was running), and any rows still in
+    ``PENDING`` become ``SKIPPED``.
+    """
+    new_states = dict(states)
+    if active is not None:
+        new_states[active] = StageStatus.FAILED if failed else StageStatus.DONE
+    for step in pipeline:
+        if new_states.get(step.stage_id) == StageStatus.PENDING:
+            new_states[step.stage_id] = StageStatus.SKIPPED
+    return new_states
+
+
+# ── Qt widget ───────────────────────────────────────────────────────────
+
+
+# Per-status mapping from status to glyph render
+_GLYPH_FOR_STATUS: dict[StageStatus, str] = {
+    StageStatus.PENDING: "○",
+    StageStatus.CURRENT: "●",
+    StageStatus.DONE: "✓",
+    StageStatus.SKIPPED: "–",
+    StageStatus.FAILED: "✕",
+}
+
+
+class _StageRow(QFrame):
+    """Single checklist row: glyph + label."""
+
+    def __init__(self, step: SyncStage, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("stageRow")
+        self._step = step
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 4, 0, 4)
+        layout.setSpacing(10)
+
+        # Fixed-width glyph column so labels line up regardless of which
+        # status icon is currently rendered.
+        self._glyph = QLabel(_GLYPH_FOR_STATUS[StageStatus.PENDING], self)
+        self._glyph.setFixedWidth(18)
+        self._glyph.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._glyph.setFont(QFont(FONT_FAMILY, Metrics.FONT_LG))
+        layout.addWidget(self._glyph)
+
+        self._label = QLabel(step.label, self)
+        self._label.setFont(QFont(FONT_FAMILY, Metrics.FONT_MD))
+        self._label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        layout.addWidget(self._label, 1)
+
+        self.set_status(StageStatus.PENDING)
+
+    @property
+    def stage_id(self) -> str:
+        return self._step.stage_id
+
+    def set_status(self, status: StageStatus) -> None:
+        self._glyph.setText(_GLYPH_FOR_STATUS[status])
+        glyph_color, text_color, bold = _row_colors(status)
+        self._glyph.setStyleSheet(f"color: {glyph_color}; background: transparent;")
+        self._label.setStyleSheet(f"color: {text_color}; background: transparent;")
+        font = self._label.font()
+        font.setBold(bold)
+        font.setItalic(status == StageStatus.SKIPPED)
+        self._label.setFont(font)
+
+
+def _row_colors(status: StageStatus) -> tuple[str, str, bool]:
+    """Return ``(glyph_color, label_color, bold_label)`` for a status."""
+    if status == StageStatus.CURRENT:
+        return Colors.ACCENT, Colors.TEXT_PRIMARY, True
+    if status == StageStatus.DONE:
+        return Colors.SUCCESS, Colors.TEXT_SECONDARY, False
+    if status == StageStatus.FAILED:
+        return Colors.DANGER, Colors.TEXT_PRIMARY, True
+    if status == StageStatus.SKIPPED:
+        return Colors.TEXT_DISABLED, Colors.TEXT_DISABLED, False
+    # PENDING
+    return Colors.TEXT_TERTIARY, Colors.TEXT_TERTIARY, False
+
+
+class SyncStagesPanel(QWidget):
+    """Left-side checklist that ticks off sync stages as they complete.
+
+    The widget owns the state machine state and rebuilds rows lazily when
+    a different pipeline is supplied.  External callers should treat it
+    as fire-and-forget:
+
+      * call :meth:`reset_for_pipeline` (or pass the pipeline at construct
+        time) before a sync run starts,
+      * call :meth:`notify_stage` from the progress callback for every
+        ``SyncProgress.stage`` value,
+      * call :meth:`finalize` once when the run ends.
+    """
+
+    def __init__(
+        self,
+        pipeline: Sequence[SyncStage] = DEFAULT_PIPELINE,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("syncStagesPanel")
+        self.setStyleSheet(f"#syncStagesPanel {{ background: {Colors.SURFACE}; border-right: 1px solid {Colors.BORDER_SUBTLE};}}")
+
+        self._outer = QVBoxLayout(self)
+        self._outer.setContentsMargins(20, 24, 20, 24)
+        self._outer.setSpacing(10)
+
+        self._title = QLabel("Sync steps", self)
+        self._title.setFont(QFont(FONT_FAMILY, Metrics.FONT_LG, QFont.Weight.DemiBold))
+        self._title.setStyleSheet(f"color: {Colors.TEXT_PRIMARY}; background: transparent;")
+        self._outer.addWidget(self._title)
+
+        self._rows_container = QWidget(self)
+        self._rows_layout = QVBoxLayout(self._rows_container)
+        self._rows_layout.setContentsMargins(0, 0, 0, 0)
+        self._rows_layout.setSpacing(2)
+        self._outer.addWidget(self._rows_container)
+
+        self._outer.addStretch(1)
+
+        self._pipeline: tuple[SyncStage, ...] = ()
+        self._states: dict[str, StageStatus] = {}
+        self._active: str | None = None
+        self._rows: dict[str, _StageRow] = {}
+
+        self.reset_for_pipeline(pipeline)
+
+    # ── Public API ──────────────────────────────────────────────────
+
+    def reset_for_pipeline(self, pipeline: Sequence[SyncStage]) -> None:
+        """Replace the row set and reset all rows to ``PENDING``."""
+        self._pipeline = tuple(pipeline)
+        self._states = init_states(self._pipeline)
+        self._active = None
+
+        # Rebuild rows from scratch — pipelines are short (~13 entries).
+        for row in self._rows.values():
+            row.setParent(None)
+            row.deleteLater()
+        self._rows.clear()
+
+        for step in self._pipeline:
+            row = _StageRow(step, self._rows_container)
+            self._rows_layout.addWidget(row)
+            self._rows[step.stage_id] = row
+
+    def notify_stage(self, stage: str) -> None:
+        """Apply one stage event from the executor's progress callback."""
+        self._states, self._active = apply_stage_event(
+            self._pipeline,
+            self._states,
+            self._active,
+            stage,
+        )
+        self._refresh_rows()
+
+    def end_of_sync(self, *, failed: bool = False) -> None:
+        """Mark the run as finished — active becomes DONE/FAILED, PENDING becomes SKIPPED."""
+        self._states = finalize_states_for_end_of_sync(
+            self._pipeline,
+            self._states,
+            self._active,
+            failed=failed,
+        )
+        self._active = None
+        self._refresh_rows()
+
+    # ── Test introspection ──────────────────────────────────────────
+    # Exposed just for tests
+
+    def states_snapshot(self) -> dict[str, StageStatus]:
+        return dict(self._states)
+
+    def active_stage(self) -> str | None:
+        return self._active
+
+    # ── Internal ────────────────────────────────────────────────────
+
+    def _refresh_rows(self) -> None:
+        for stage_id, row in self._rows.items():
+            row.set_status(self._states.get(stage_id, StageStatus.PENDING))
+
+
+__all__ = [
+    "DEFAULT_PIPELINE",
+    "StageStatus",
+    "SyncStage",
+    "SyncStagesPanel",
+    "apply_stage_event",
+    "finalize_states_for_end_of_sync",
+    "init_states",
+]

--- a/GUI/widgets/syncStagesPanel.py
+++ b/GUI/widgets/syncStagesPanel.py
@@ -203,6 +203,14 @@ _GLYPH_FOR_STATUS: dict[StageStatus, str] = {
     StageStatus.FAILED: "✕",
 }
 
+_TOOLTIP_FOR_STATUS: dict[StageStatus, str] = {
+    StageStatus.PENDING: "Waiting",
+    StageStatus.CURRENT: "Running",
+    StageStatus.DONE: "Done",
+    StageStatus.SKIPPED: "No work needed",
+    StageStatus.FAILED: "Failed",
+}
+
 
 class _StageRow(QFrame):
     """Single checklist row: glyph + label."""
@@ -211,9 +219,10 @@ class _StageRow(QFrame):
         super().__init__(parent)
         self.setObjectName("stageRow")
         self._step = step
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 4, 0, 4)
+        layout.setContentsMargins(8, 5, 8, 5)
         layout.setSpacing(10)
 
         # Fixed-width glyph column so labels line up regardless of which
@@ -227,6 +236,7 @@ class _StageRow(QFrame):
         self._label = QLabel(step.label, self)
         self._label.setFont(QFont(FONT_FAMILY, Metrics.FONT_MD))
         self._label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self._label.setWordWrap(True)
         layout.addWidget(self._label, 1)
 
         self.set_status(StageStatus.PENDING)
@@ -238,6 +248,16 @@ class _StageRow(QFrame):
     def set_status(self, status: StageStatus) -> None:
         self._glyph.setText(_GLYPH_FOR_STATUS[status])
         glyph_color, text_color, bold = _row_colors(status)
+        background, border_left = _row_frame_style(status)
+        self.setToolTip(f"{self._step.label}: {_TOOLTIP_FOR_STATUS[status]}")
+        self.setStyleSheet(
+            "QFrame#stageRow {"
+            f"background: {background};"
+            "border: 1px solid transparent;"
+            f"border-left: 3px solid {border_left};"
+            "border-radius: 6px;"
+            "}"
+        )
         self._glyph.setStyleSheet(f"color: {glyph_color}; background: transparent;")
         self._label.setStyleSheet(f"color: {text_color}; background: transparent;")
         font = self._label.font()
@@ -258,6 +278,15 @@ def _row_colors(status: StageStatus) -> tuple[str, str, bool]:
         return Colors.TEXT_DISABLED, Colors.TEXT_DISABLED, False
     # PENDING
     return Colors.TEXT_TERTIARY, Colors.TEXT_TERTIARY, False
+
+
+def _row_frame_style(status: StageStatus) -> tuple[str, str]:
+    """Return ``(background, left_border)`` for a row frame."""
+    if status == StageStatus.CURRENT:
+        return Colors.ACCENT_MUTED, Colors.ACCENT
+    if status == StageStatus.FAILED:
+        return Colors.DANGER_DIM, Colors.DANGER
+    return "transparent", "transparent"
 
 
 class SyncStagesPanel(QWidget):
@@ -293,12 +322,11 @@ class SyncStagesPanel(QWidget):
         self._outer.addWidget(self._title)
 
         self._rows_container = QWidget(self)
+        self._rows_container.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self._rows_layout = QVBoxLayout(self._rows_container)
         self._rows_layout.setContentsMargins(0, 0, 0, 0)
         self._rows_layout.setSpacing(2)
-        self._outer.addWidget(self._rows_container)
-
-        self._outer.addStretch(1)
+        self._outer.addWidget(self._rows_container, 1)
 
         self._pipeline: tuple[SyncStage, ...] = ()
         self._states: dict[str, StageStatus] = {}
@@ -323,7 +351,7 @@ class SyncStagesPanel(QWidget):
 
         for step in self._pipeline:
             row = _StageRow(step, self._rows_container)
-            self._rows_layout.addWidget(row)
+            self._rows_layout.addWidget(row, 1)
             self._rows[step.stage_id] = row
 
     def notify_stage(self, stage: str) -> None:

--- a/SyncEngine/sync_executor.py
+++ b/SyncEngine/sync_executor.py
@@ -1176,10 +1176,28 @@ class SyncExecutor:
 
     def _backpatch_new_tracks(self, ctx: _SyncContext) -> None:
         """Create mapping entries for newly added tracks (db_track_ids now assigned)."""
-        for track in ctx.new_tracks:
+        if not ctx.new_tracks:
+            return
+
+        total = len(ctx.new_tracks)
+        ctx.progress(
+            "backpatch",
+            0,
+            total,
+            message="Recording source file identities...",
+        )
+
+        for index, track in enumerate(ctx.new_tracks, start=1):
             obj_key = id(track)
             fp = ctx.new_track_fingerprints.get(obj_key)
             info = ctx.new_track_info.get(obj_key)
+            label = getattr(track, "title", "") or getattr(track, "location", "") or "track"
+            ctx.progress(
+                "backpatch",
+                index,
+                total,
+                message=f"Recording source identity for {label}",
+            )
             if fp and info and track.db_track_id != 0:
                 pc_track, ipod_dest, was_transcoded = info[:3]
                 # Re-stat the source file to capture post-fingerprint

--- a/scripts/architecture_rules.json
+++ b/scripts/architecture_rules.json
@@ -1,27 +1,28 @@
 {
   "allowed_gui_forbidden_imports": {
-    "GUI/widgets/MBListView.py": [
-      "SyncEngine._playlist_builder"
-    ],
-    "GUI/widgets/musicBrowser.py": [
-      "ipod_device"
-    ],
-    "GUI/widgets/photoBrowser.py": [
-      "SyncEngine.photos",
-      "ipod_device.artwork"
-    ],
+    "GUI/app.py": ["SyncEngine.album_chapters"],
+    "GUI/widgets/MBListView.py": ["SyncEngine._playlist_builder"],
+    "GUI/widgets/devicePicker.py": ["ipod_device"],
+    "GUI/widgets/musicBrowser.py": ["SyncEngine.album_chapters", "ipod_device"],
+    "GUI/widgets/photoBrowser.py": ["SyncEngine.photos", "ipod_device.artwork"],
     "GUI/widgets/podcastBrowser.py": [
+      "PodcastManager.artwork",
       "PodcastManager.feed_parser",
       "PodcastManager.models",
+      "PodcastManager.network_errors",
       "PodcastManager.podcast_sync",
-      "PodcastManager.subscription_store"
+      "PodcastManager.subscription_store",
+      "SyncEngine.contracts"
     ],
     "GUI/widgets/podcastSearchDialog.py": [
-      "PodcastManager.itunes_search"
+      "PodcastManager.itunes_search",
+      "PodcastManager.network_errors"
     ],
     "GUI/widgets/selectiveSyncBrowser.py": [
       "SyncEngine.pc_library",
-      "SyncEngine.photos"
+      "SyncEngine.photos",
+      "SyncEngine.sync_playlist_files",
+      "SyncEngine.unknown_metadata"
     ],
     "GUI/widgets/settingsPage.py": [
       "SyncEngine.audio_fingerprint",
@@ -37,6 +38,7 @@
       "ipod_device.authority",
       "ipod_device.info",
       "ipod_device.scanner",
+      "ipod_device.virtual",
       "ipod_device.vpd_libusb",
       "ipod_device.vpd_linux"
     ],
@@ -71,8 +73,9 @@
     "GUI/widgets/musicBrowser.py": 2,
     "GUI/widgets/playlistBrowser.py": 7,
     "GUI/widgets/podcastBrowser.py": 4,
+    "GUI/widgets/pooledCardGrid.py": 2,
     "GUI/widgets/selectiveSyncBrowser.py": 2,
-    "GUI/widgets/settingsPage.py": 2,
+    "GUI/widgets/settingsPage.py": 5,
     "GUI/widgets/sidebar.py": 1,
     "GUI/widgets/syncReview.py": 1,
     "PodcastManager/downloader.py": 2,
@@ -80,16 +83,18 @@
     "SQLiteDB_Writer/cbk_writer.py": 3,
     "SyncEngine/audio_fingerprint.py": 2,
     "SyncEngine/dependency_manager.py": 1,
+    "SyncEngine/fingerprint_diff_engine.py": 2,
     "SyncEngine/photos.py": 2,
     "SyncEngine/sync_executor.py": 5,
     "SyncEngine/transcode_cache.py": 1,
     "SyncEngine/transcoder.py": 6,
     "app_core/bootstrap.py": 3,
+    "app_core/runtime.py": 1,
     "iTunesDB_Writer/hash72.py": 1,
     "iTunesDB_Writer/mhbd_writer.py": 3,
     "ipod_device/authority.py": 1,
     "ipod_device/dump.py": 1,
-    "ipod_device/info.py": 4,
+    "ipod_device/info.py": 6,
     "ipod_device/usb_backend.py": 1,
     "ipod_device/vpd_iokit.py": 1,
     "ipod_device/vpd_libusb.py": 5

--- a/tests/test_chaptered_aggregate_mapping.py
+++ b/tests/test_chaptered_aggregate_mapping.py
@@ -334,10 +334,13 @@ def test_backpatch_split_track_uses_original_source_mapping_without_aggregate_fi
             "source_hash": "source-hash",
         },
     )
+    progress_stages: list[tuple[str, int, int]] = []
     ctx = _SyncContext(
         plan=SyncPlan(),
         mapping=MappingFile(),
-        progress_callback=None,
+        progress_callback=lambda progress: progress_stages.append(
+            (progress.stage, progress.current, progress.total)
+        ),
         dry_run=False,
         write_back_to_pc=False,
         _is_cancelled=None,
@@ -358,6 +361,7 @@ def test_backpatch_split_track_uses_original_source_mapping_without_aggregate_fi
     assert entry.aggregate_kind is None
     assert entry.contains_fingerprints is None
     assert "containsFingerprints" not in entry.to_dict()
+    assert progress_stages == [("backpatch", 0, 1), ("backpatch", 1, 1)]
 
 
 def test_backpatch_split_track_does_not_use_generated_hash_for_original_source(tmp_path) -> None:

--- a/tests/test_sync_stages_panel.py
+++ b/tests/test_sync_stages_panel.py
@@ -1,0 +1,331 @@
+"""Tests for the sync-stages-panel state machine.
+
+The widget itself is a thin renderer; all of the interesting behaviour
+lives in ``apply_stage_event`` / ``finalize_states`` which transition a
+plain dict of ``StageStatus`` values.  These tests exercise that pure
+logic so we can catch regressions without spinning up Qt.
+"""
+
+from __future__ import annotations
+
+from GUI.widgets.syncStagesPanel import (
+    DEFAULT_PIPELINE,
+    StageStatus,
+    SyncStage,
+    apply_stage_event,
+    finalize_states_for_end_of_sync,
+    init_states,
+)
+
+# ── A small fixed test pipeline ─────────────────────────────────────────
+# Using a dedicated 5-step pipeline keeps these tests independent of
+# tweaks to ``DEFAULT_PIPELINE`` (which represents the real executor).
+
+_TEST_PIPELINE: tuple[SyncStage, ...] = (
+    SyncStage("backup", "Backup", frozenset({"backup"})),
+    SyncStage("remove", "Remove", frozenset({"remove", "remove_chapter"})),
+    SyncStage("add", "Add", frozenset({"add"})),
+    SyncStage(
+        "scrobble",
+        "Scrobble",
+        frozenset({"scrobble_listenbrainz", "scrobble_lastfm"}),
+    ),
+    SyncStage("write", "Write database", frozenset({"write_database"})),
+)
+
+
+# ── init_states ─────────────────────────────────────────────────────────
+
+
+def test_init_states_marks_every_step_pending() -> None:
+    states = init_states(_TEST_PIPELINE)
+    assert states == {
+        "backup": StageStatus.PENDING,
+        "remove": StageStatus.PENDING,
+        "add": StageStatus.PENDING,
+        "scrobble": StageStatus.PENDING,
+        "write": StageStatus.PENDING,
+    }
+
+
+# ── apply_stage_event ───────────────────────────────────────────────────
+
+
+def test_first_event_marks_only_that_step_current() -> None:
+    # Sync starts at backup → only "backup" becomes CURRENT, rest stay PENDING.
+    states, active = apply_stage_event(
+        _TEST_PIPELINE,
+        init_states(_TEST_PIPELINE),
+        None,
+        "backup",
+    )
+    assert active == "backup"
+    assert states["backup"] == StageStatus.CURRENT
+    assert all(states[k] == StageStatus.PENDING for k in ("remove", "add", "scrobble", "write"))
+
+
+def test_advancing_marks_previous_done_and_new_current() -> None:
+    # backup → add: backup becomes DONE, add becomes CURRENT.  remove was
+    # passed over with no work, so it gets SKIPPED.
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "backup")
+    states, active = apply_stage_event(_TEST_PIPELINE, states, active, "add")
+
+    assert active == "add"
+    assert states["backup"] == StageStatus.DONE
+    assert states["remove"] == StageStatus.SKIPPED
+    assert states["add"] == StageStatus.CURRENT
+
+
+def test_skip_is_only_applied_to_pending_steps() -> None:
+    # If a step is somehow already DONE/CURRENT (shouldn't happen but the
+    # function defends against it), the skip pass leaves it alone.
+    states = init_states(_TEST_PIPELINE)
+    states["backup"] = StageStatus.DONE
+    states["remove"] = StageStatus.DONE  # pretend we ran it
+
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "scrobble_listenbrainz")
+    assert active == "scrobble"
+    assert states["backup"] == StageStatus.DONE  # untouched
+    assert states["remove"] == StageStatus.DONE  # untouched
+    assert states["add"] == StageStatus.SKIPPED  # was PENDING, now SKIPPED
+    assert states["scrobble"] == StageStatus.CURRENT
+
+
+def test_alias_stage_maps_to_canonical_row() -> None:
+    # ``remove_chapter`` is an alias of the ``remove`` row.
+    states, active = apply_stage_event(
+        _TEST_PIPELINE,
+        init_states(_TEST_PIPELINE),
+        None,
+        "remove_chapter",
+    )
+    assert active == "remove"
+    assert states["remove"] == StageStatus.CURRENT
+
+
+def test_repeated_alias_within_same_step_is_noop() -> None:
+    # Switching from one scrobble service to another mustn't re-flip the
+    # state machine — both are aliases of the same row.
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "scrobble_listenbrainz")
+    snapshot = dict(states)
+    states_after, active_after = apply_stage_event(_TEST_PIPELINE, states, active, "scrobble_lastfm")
+
+    assert active_after == "scrobble"
+    assert states_after == snapshot
+
+
+def test_unknown_stage_is_ignored() -> None:
+    # ``transcode`` is a sub-stage that's intentionally not in the pipeline;
+    # the executor emits it inside the ``add`` phase.  We must keep "add"
+    # CURRENT and not touch anything else.
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "add")
+    snapshot = dict(states)
+
+    states, active = apply_stage_event(_TEST_PIPELINE, states, active, "transcode")
+    assert active == "add"
+    assert states == snapshot
+
+
+def test_repeated_event_for_active_step_is_noop() -> None:
+    # The executor fires many events for the same stage as work progresses;
+    # the state machine only reacts to transitions.
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "add")
+    snapshot = dict(states)
+
+    states, active = apply_stage_event(_TEST_PIPELINE, states, active, "add")
+    assert active == "add"
+    assert states == snapshot
+
+
+def test_input_states_dict_is_not_mutated() -> None:
+    # Callers store the dict and pass it back in; we must return a new one.
+    states = init_states(_TEST_PIPELINE)
+    before = dict(states)
+
+    apply_stage_event(_TEST_PIPELINE, states, None, "add")
+
+    assert states == before
+
+
+# ── finalize_states ─────────────────────────────────────────────────────
+
+
+def test_finalize_marks_active_done_and_remaining_skipped() -> None:
+    # Sync ended successfully while in the middle of "add".  add → DONE,
+    # later steps that never fired → SKIPPED.
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "backup")
+    states, active = apply_stage_event(_TEST_PIPELINE, states, active, "add")
+
+    final = finalize_states_for_end_of_sync(_TEST_PIPELINE, states, active)
+    assert final["backup"] == StageStatus.DONE
+    assert final["remove"] == StageStatus.SKIPPED
+    assert final["add"] == StageStatus.DONE
+    assert final["scrobble"] == StageStatus.SKIPPED
+    assert final["write"] == StageStatus.SKIPPED
+
+
+def test_finalize_marks_active_failed_when_sync_failed() -> None:
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "add")
+
+    final = finalize_states_for_end_of_sync(_TEST_PIPELINE, states, active, failed=True)
+    assert final["add"] == StageStatus.FAILED
+    # Steps after the failure are still considered "didn't run".
+    assert final["scrobble"] == StageStatus.SKIPPED
+    assert final["write"] == StageStatus.SKIPPED
+
+
+def test_finalize_with_no_active_step_marks_all_pending_skipped() -> None:
+    # Nothing fired (e.g. an empty sync).  Every step ends up SKIPPED.
+    states = init_states(_TEST_PIPELINE)
+    final = finalize_states_for_end_of_sync(_TEST_PIPELINE, states, None)
+    assert all(v == StageStatus.SKIPPED for v in final.values())
+
+
+def test_finalize_does_not_overwrite_done_steps() -> None:
+    states = init_states(_TEST_PIPELINE)
+    states, active = apply_stage_event(_TEST_PIPELINE, states, None, "backup")
+    states, active = apply_stage_event(_TEST_PIPELINE, states, active, "remove")
+    states, active = apply_stage_event(_TEST_PIPELINE, states, active, "write_database")
+
+    # Before finalize: backup DONE, remove DONE, add SKIPPED (passed over),
+    # scrobble SKIPPED (passed over), write CURRENT.
+    final = finalize_states_for_end_of_sync(_TEST_PIPELINE, states, active)
+    assert final["backup"] == StageStatus.DONE
+    assert final["remove"] == StageStatus.DONE
+    assert final["add"] == StageStatus.SKIPPED
+    assert final["scrobble"] == StageStatus.SKIPPED
+    assert final["write"] == StageStatus.DONE
+
+
+# ── DEFAULT_PIPELINE smoke tests ────────────────────────────────────────
+
+
+def test_default_pipeline_covers_known_executor_stages() -> None:
+    # Every stage_id the executor actually emits should map to *some* row
+    # in the canonical pipeline.  This guards against the executor adding
+    # a new stage without a corresponding checklist row.
+    executor_stages = {
+        "backup",
+        "remove",
+        "remove_chapter",
+        "replace_remove",
+        "update_file",
+        "update_metadata",
+        "podcast_download",
+        "add",
+        "sound_check",
+        "sync_playcount",
+        "sync_rating",
+        "scrobble",
+        "scrobble_listenbrainz",
+        "scrobble_lastfm",
+        "playlists",
+        "write_database",
+        "backpatch",
+        "photo_prepare",
+        "photo_write",
+        "photo_compact",
+    }
+    covered = {s for s in executor_stages if any(step.matches(s) for step in DEFAULT_PIPELINE)}
+    assert covered == executor_stages, f"executor stages without a pipeline row: {executor_stages - covered}"
+
+
+def test_default_pipeline_full_walkthrough() -> None:
+    # Drive the canonical pipeline through every phase in order and make
+    # sure the final state has no leftover PENDING rows.
+    states = init_states(DEFAULT_PIPELINE)
+    active: str | None = None
+
+    for stage in (
+        "backup",
+        "remove",
+        "update_file",
+        "update_metadata",
+        "podcast_download",
+        "add",
+        "sound_check",
+        "sync_playcount",
+        "scrobble_lastfm",
+        "write_database",
+        "backpatch",
+        "photo_write",
+    ):
+        states, active = apply_stage_event(DEFAULT_PIPELINE, states, active, stage)
+
+    final = finalize_states_for_end_of_sync(DEFAULT_PIPELINE, states, active)
+    # Every named step that we fired should be DONE; the only one we
+    # skipped (replace_remove) should be SKIPPED.
+    assert final["replace_remove"] == StageStatus.SKIPPED
+    expected_done = {
+        "backup",
+        "remove",
+        "update_file",
+        "update_metadata",
+        "podcast_download",
+        "add",
+        "sound_check",
+        "playcount",
+        "scrobble",
+        "write_database",
+        "backpatch",
+        "photo",
+    }
+    for key in expected_done:
+        assert final[key] == StageStatus.DONE, f"{key} should be DONE, got {final[key]}"
+
+
+# ── Qt widget smoke tests ───────────────────────────────────────────────
+
+
+def test_panel_widget_reflects_state_machine(qtbot) -> None:
+    """End-to-end: notify_stage on the widget should rebuild row visuals."""
+    from GUI.widgets.syncStagesPanel import SyncStagesPanel
+
+    panel = SyncStagesPanel(_TEST_PIPELINE)
+    qtbot.addWidget(panel)
+
+    # Fresh panel: every row PENDING.
+    initial = panel.states_snapshot()
+    assert all(v == StageStatus.PENDING for v in initial.values())
+    assert panel.active_stage() is None
+
+    # Drive a transition.
+    panel.notify_stage("backup")
+    assert panel.active_stage() == "backup"
+    assert panel.states_snapshot()["backup"] == StageStatus.CURRENT
+
+    panel.notify_stage("add")
+    snap = panel.states_snapshot()
+    assert snap["backup"] == StageStatus.DONE
+    assert snap["remove"] == StageStatus.SKIPPED
+    assert snap["add"] == StageStatus.CURRENT
+
+    panel.end_of_sync()
+    final = panel.states_snapshot()
+    assert final["add"] == StageStatus.DONE
+    assert final["scrobble"] == StageStatus.SKIPPED
+    assert final["write"] == StageStatus.SKIPPED
+    assert panel.active_stage() is None
+
+
+def test_panel_reset_for_pipeline_clears_previous_state(qtbot) -> None:
+    """Reusing the panel for a fresh sync wipes the prior run's status."""
+    from GUI.widgets.syncStagesPanel import SyncStagesPanel
+
+    panel = SyncStagesPanel(_TEST_PIPELINE)
+    qtbot.addWidget(panel)
+
+    panel.notify_stage("add")
+    panel.end_of_sync()
+    assert panel.states_snapshot()["add"] == StageStatus.DONE
+
+    # Second sync run — every row goes back to PENDING.
+    panel.reset_for_pipeline(_TEST_PIPELINE)
+    assert all(v == StageStatus.PENDING for v in panel.states_snapshot().values())
+    assert panel.active_stage() is None


### PR DESCRIPTION
This was my first pass for adding a left side indication panel during sync to show progress.

Let me know anything else I can do to help / also feel free to re-write or change it up however you want (:

I don't love having `DEFAULT_PIPELINE` but I didn't spot a good gui layer to put this in otherwise as the current progress view wasn't aware of the stages; and the SyncEngine objects rapidly got harder to follow.

Closes #121

EDIT: I'll re-push later to fixup CI I didn't run locally.
EDIT: CI updated & rebased