### PR TITLE
feat: allow more parallel workers than 8

### DIFF
--- a/GUI/widgets/settingsPage.py
+++ b/GUI/widgets/settingsPage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import threading
 import urllib.error
 import urllib.parse
@@ -1561,7 +1562,7 @@ class SettingsPage(QWidget):
             "Overall concurrent sync work. This controls how many files can be "
             "prepared, fingerprinted, transcoded, or copied at once. "
             "Auto uses your CPU core count (capped at 8).",
-            options=["Auto", "1", "2", "4", "6", "8"],
+            options=["Auto", "1"] + [str(i) for i in range(2, os.cpu_count() + 1, 2)],
             current="Auto",
         )
         self.device_write_workers = ComboRow(
@@ -2323,7 +2324,7 @@ class SettingsPage(QWidget):
             self.video_preset.combo.setCurrentIndex(idx)
 
         # Sync workers → combo text
-        workers_map = {0: "Auto", 1: "1", 2: "2", 4: "4", 6: "6", 8: "8"}
+        workers_map = {0: "Auto", 1: "1", **{i: str(i) for i in range(2, os.cpu_count() + 1, 2)}}
         sw_text = workers_map.get(s.sync_workers, "Auto")
         idx = self.sync_workers.combo.findText(sw_text)
         if idx >= 0:


### PR DESCRIPTION
Hello there,

I have a CPU with 16 cores / 32 threads and I sync my iPod with transcoding to lossy AAC. My iPod is flash modded, so copying is really fast. Sometimes my iPod is waiting because the transcoding takes longer than transcoding. I'd like to use my CPU and increase the parallel transcodes.