### PR TITLE
feat: headless iPod sync CLI (iopod)

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -1,0 +1,68 @@
+"""Config file loading for iopenpod-sync CLI."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+DEFAULT_CONFIG_PATH = Path("~/.config/iopenpodcli/config.yaml").expanduser()
+
+
+@dataclass
+class PodcastConfig:
+    url: str
+    keep_episodes: int = 5
+
+
+@dataclass
+class SyncConfig:
+    # Music source — directory to scan for audio files
+    music_path: str = "~/Music"
+    # M3U / folder-based playlist files to sync; relative paths resolve from music_path
+    playlists: list[str] = field(default_factory=list)
+    # Podcast feeds
+    podcasts: list[PodcastConfig] = field(default_factory=list)
+    # Pull ratings from iPod back to local file tags (via mutagen)
+    pull_ratings: bool = True
+    # Pull play counts from iPod back to local file tags
+    pull_playcounts: bool = True
+    # "ipod_wins" | "pc_wins" | "higher_wins"
+    rating_strategy: str = "ipod_wins"
+
+
+def load_config(path: Path | str | None = None) -> SyncConfig:
+    config_path = Path(path).expanduser() if path else DEFAULT_CONFIG_PATH
+
+    if not config_path.exists():
+        return SyncConfig()
+
+    if yaml is None:
+        raise RuntimeError(
+            "PyYAML is required to read the config file. Install it with: pip install pyyaml"
+        )
+
+    raw: dict[str, Any] = yaml.safe_load(config_path.read_text()) or {}
+
+    podcasts = [
+        PodcastConfig(
+            url=p["url"] if isinstance(p, dict) else str(p),
+            keep_episodes=int(p.get("keep_episodes", 5)) if isinstance(p, dict) else 5,
+        )
+        for p in raw.get("podcasts", [])
+    ]
+
+    return SyncConfig(
+        music_path=str(raw.get("music_path", "~/Music")),
+        playlists=[str(p) for p in raw.get("playlists", [])],
+        podcasts=podcasts,
+        pull_ratings=bool(raw.get("pull_ratings", True)),
+        pull_playcounts=bool(raw.get("pull_playcounts", True)),
+        rating_strategy=str(raw.get("rating_strategy", "ipod_wins")),
+    )

--- a/cli/device.py
+++ b/cli/device.py
@@ -1,0 +1,47 @@
+"""Device detection helpers for the CLI."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ipod_device.scanner import scan_for_ipods
+from ipod_device.info import DeviceInfo
+
+logger = logging.getLogger(__name__)
+
+
+def find_ipod(mount_hint: str | None = None) -> tuple[DeviceInfo, str] | None:
+    """Return (DeviceInfo, itunesdb_path) for the first found iPod.
+
+    If *mount_hint* is given, only that mount path is considered.
+    Returns None when no iPod is found.
+    """
+    if mount_hint:
+        # Synthesise a minimal scan from the user-supplied path
+        db_path = _itunesdb_path(mount_hint)
+        if not Path(db_path).exists():
+            logger.error("No iTunesDB found at %s", db_path)
+            return None
+        devices = scan_for_ipods()
+        for d in devices:
+            if str(d.mount_path) == str(mount_hint):
+                return d, db_path
+        # Fallback: return path without full DeviceInfo (checksum detection still works)
+        logger.warning("Device info not found for %s — using filesystem-only mode", mount_hint)
+        return None
+
+    devices = scan_for_ipods()
+    if not devices:
+        return None
+
+    device = devices[0]
+    if len(devices) > 1:
+        logger.info("Multiple iPods found — using first: %s", device.display_name)
+
+    db_path = _itunesdb_path(str(device.mount_path))
+    return device, db_path
+
+
+def _itunesdb_path(mount: str) -> str:
+    return str(Path(mount) / "iPod_Control" / "iTunes" / "iTunesDB")

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,129 @@
+"""iopenpod-sync — headless iPod sync CLI.
+
+Usage:
+    iopenpod-sync [options]
+
+Options:
+    --config PATH       Config file path (default: ~/.config/iopenpodcli/config.yaml)
+    --device PATH       iPod mount path (auto-detect if omitted)
+    --dry-run           Plan but don't write anything
+    --no-music          Skip music sync
+    --no-podcasts       Skip podcast sync
+    --list-devices      List connected iPods and exit
+    --init-config       Write an example config and exit
+    -v, --verbose       Verbose logging
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+
+def _list_devices() -> None:
+    from ipod_device.scanner import scan_for_ipods
+
+    devices = scan_for_ipods()
+    if not devices:
+        print("No iPods found.")
+        return
+    for d in devices:
+        model = getattr(d, "model_family", "") or ""
+        gen = getattr(d, "generation", "") or ""
+        cap = getattr(d, "capacity_gb", "") or ""
+        mount = getattr(d, "mount_path", "")
+        display = getattr(d, "display_name", "") or str(mount)
+        print(f"  {display}  [{mount}]  {model} {gen} {cap}GB".rstrip())
+
+
+def _init_config(path: str) -> None:
+    from pathlib import Path
+
+    target = Path(path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    example = """\
+# iopenpod-sync configuration
+# See: https://github.com/TristonYoder/iOpenPod
+
+# Root directory containing your music files
+music_path: ~/Music
+
+# M3U / M3U8 playlist files to sync (paths relative to music_path, or absolute).
+# Leave empty to sync all music in music_path.
+playlists:
+  # - Favorites.m3u
+  # - Workout.m3u8
+
+# Podcast feeds
+podcasts:
+  # - url: https://feeds.example.com/podcast.rss
+  #   keep_episodes: 5
+
+# Sync ratings from iPod back to PC file tags (via mutagen)
+pull_ratings: true
+
+# Sync play counts from iPod back to PC file tags
+pull_playcounts: true
+
+# Rating conflict resolution: ipod_wins | pc_wins | higher_wins
+rating_strategy: ipod_wins
+"""
+    target.write_text(example)
+    print(f"Config written to {target}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="iopenpod-sync",
+        description="Headless iPod sync — music playlists + podcasts + ratings",
+    )
+    parser.add_argument("--config", metavar="PATH", help="Config file path")
+    parser.add_argument("--device", metavar="PATH", help="iPod mount path (auto-detect if omitted)")
+    parser.add_argument("--dry-run", action="store_true", help="Plan but don't write")
+    parser.add_argument("--no-music", action="store_true", help="Skip music sync")
+    parser.add_argument("--no-podcasts", action="store_true", help="Skip podcast sync")
+    parser.add_argument("--list-devices", action="store_true", help="List connected iPods and exit")
+    parser.add_argument("--init-config", metavar="PATH", nargs="?", const="~/.config/iopenpodcli/config.yaml",
+                        help="Write example config and exit")
+    parser.add_argument("-v", "--verbose", action="store_true")
+
+    args = parser.parse_args()
+    _setup_logging(args.verbose)
+
+    if args.list_devices:
+        _list_devices()
+        sys.exit(0)
+
+    if args.init_config:
+        _init_config(args.init_config)
+        sys.exit(0)
+
+    from cli.config import load_config
+    from cli.sync import run_sync
+
+    config = load_config(args.config)
+
+    sys.exit(
+        run_sync(
+            config=config,
+            mount_hint=args.device,
+            dry_run=args.dry_run,
+            skip_music=args.no_music,
+            skip_podcasts=args.no_podcasts,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/sync.py
+++ b/cli/sync.py
@@ -1,0 +1,355 @@
+"""Core sync orchestration for the iopenpod-sync CLI.
+
+Drives the Qt-free SyncEngine to:
+  1. Detect the connected iPod
+  2. Load its iTunesDB (tracks + playlists)
+  3. Run a plan+execute cycle for music (local folder → selected playlists)
+  4. Download and sync configured podcast feeds
+  5. Optionally pull ratings/playcounts back to PC file tags
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from cli.config import SyncConfig
+from cli.device import find_ipod
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Progress helpers
+# ---------------------------------------------------------------------------
+
+def _progress_cb(progress: Any) -> None:
+    stage = str(getattr(progress, "stage", ""))
+    current = getattr(progress, "current", 0) or 0
+    total = getattr(progress, "total", 0) or 0
+    message = getattr(progress, "message", "") or ""
+
+    if total and current:
+        bar = f" [{current}/{total}]"
+    else:
+        bar = ""
+
+    if message:
+        print(f"  [{stage}]{bar} {message}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Music sync
+# ---------------------------------------------------------------------------
+
+def _build_pc_folders(config: SyncConfig) -> tuple[Any, ...]:
+    """Build pc_folders entries from the config's music_path.
+
+    When specific playlists are configured, we request both "music" and
+    "playlists" media types so the engine discovers the M3U files.
+    Without playlists, we scan for music only.
+    """
+    from infrastructure.media_folders import MediaFolderEntry
+
+    music_path = str(Path(config.music_path).expanduser())
+    media_types: tuple[str, ...]
+    if config.playlists:
+        media_types = ("music", "playlists")
+    else:
+        media_types = ("music",)
+
+    return (MediaFolderEntry(directory=music_path, recurse=True, media_types=media_types),)
+
+
+def _resolve_playlist_paths(config: SyncConfig) -> frozenset[str] | None:
+    """Convert configured playlist names/paths to stable path keys.
+
+    If the user listed playlist files (absolute or relative to music_path),
+    we pass them as selected_playlist_paths so the engine syncs only those.
+    Returns None to sync all discovered playlists.
+    """
+    if not config.playlists:
+        return None
+
+    from SyncEngine.sync_playlist_files import normalize_sync_playlist_path
+
+    music_root = Path(config.music_path).expanduser()
+    resolved: set[str] = set()
+    for pl in config.playlists:
+        p = Path(pl).expanduser()
+        if not p.is_absolute():
+            p = music_root / p
+        resolved.add(normalize_sync_playlist_path(str(p)))
+
+    return frozenset(resolved)
+
+
+def run_music_sync(
+    ipod_path: str,
+    ipod_tracks: tuple[dict, ...],
+    existing_playlists: tuple[dict, ...],
+    device_info: Any,
+    device_capabilities: Any,
+    config: SyncConfig,
+    dry_run: bool = False,
+) -> bool:
+    from SyncEngine.core.engine import SyncEngine
+    from SyncEngine.core.models import (
+        EngineOperation,
+        EngineOptions,
+        EngineRequest,
+    )
+    from SyncEngine.mapping import MappingManager
+
+    pc_folders = _build_pc_folders(config)
+    selected_playlist_paths = _resolve_playlist_paths(config)
+
+    print("\n[Music] Planning sync...")
+    plan_request = EngineRequest(
+        operation=EngineOperation.PLAN,
+        ipod_path=ipod_path,
+        pc_folders=pc_folders,
+        ipod_tracks=ipod_tracks,
+        existing_playlists=existing_playlists,
+        options=EngineOptions(
+            rating_strategy=config.rating_strategy,
+            selected_playlist_paths=selected_playlist_paths,
+            write_back_to_pc=config.pull_ratings or config.pull_playcounts,
+            dry_run=dry_run,
+        ),
+        progress_callback=_progress_cb,
+        device_info=device_info,
+        device_capabilities=device_capabilities,
+    )
+
+    engine = SyncEngine()
+    plan_outcome = engine.run(plan_request)
+
+    if not plan_outcome.success:
+        for d in plan_outcome.diagnostics:
+            if d.fatal:
+                logger.error("Plan failed: %s", d.message)
+        return False
+
+    plan = plan_outcome.result
+    if plan is None:
+        logger.error("Planner returned no plan")
+        return False
+
+    # Summarise the plan
+    adds = sum(1 for item in getattr(plan, "to_add", []))
+    removes = sum(1 for item in getattr(plan, "to_remove", []))
+    updates = sum(1 for item in getattr(plan, "to_update", []))
+    print(f"[Music] Plan: +{adds} add  -{removes} remove  ~{updates} update")
+
+    if dry_run:
+        print("[Music] Dry run — skipping execution.")
+        return True
+
+    if adds == 0 and removes == 0 and updates == 0:
+        print("[Music] Already in sync.")
+        return True
+
+    print("[Music] Executing sync...")
+    mapping = MappingManager(ipod_path).load()
+    exec_request = EngineRequest(
+        operation=EngineOperation.EXECUTE,
+        ipod_path=ipod_path,
+        ipod_tracks=ipod_tracks,
+        existing_playlists=existing_playlists,
+        plan=plan,
+        mapping=mapping,
+        options=EngineOptions(
+            rating_strategy=config.rating_strategy,
+            write_back_to_pc=config.pull_ratings or config.pull_playcounts,
+            dry_run=dry_run,
+        ),
+        progress_callback=_progress_cb,
+        device_info=device_info,
+        device_capabilities=device_capabilities,
+    )
+
+    exec_outcome = engine.run(exec_request)
+    if not exec_outcome.success:
+        for d in exec_outcome.diagnostics:
+            if d.fatal:
+                logger.error("Execute failed: %s", d.message)
+        return False
+
+    print("[Music] Sync complete.")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Podcast sync
+# ---------------------------------------------------------------------------
+
+def run_podcast_sync(
+    ipod_path: str,
+    ipod_tracks: tuple[dict, ...],
+    existing_playlists: tuple[dict, ...],
+    device_info: Any,
+    device_capabilities: Any,
+    config: SyncConfig,
+    dry_run: bool = False,
+) -> bool:
+    if not config.podcasts:
+        return True
+
+    from PodcastManager.subscription_store import SubscriptionStore
+    from PodcastManager.feed_parser import fetch_feed
+    from PodcastManager.models import PodcastFeed
+    from PodcastManager.podcast_sync import build_podcast_managed_plan
+    from SyncEngine.core.engine import SyncEngine
+    from SyncEngine.core.models import (
+        EngineOperation,
+        EngineOptions,
+        EngineRequest,
+    )
+    from SyncEngine.mapping import MappingManager
+
+    # Subscription state lives on the iPod itself
+    store = SubscriptionStore(ipod_path)
+    store.load()
+
+    # Ensure all configured feeds are in the store, respecting keep_episodes
+    for pod_cfg in config.podcasts:
+        existing = next((f for f in store._feeds if f.feed_url == pod_cfg.url), None)
+        if existing is None:
+            store._feeds.append(PodcastFeed(
+                feed_url=pod_cfg.url,
+                episode_slots=pod_cfg.keep_episodes,
+            ))
+        else:
+            existing.episode_slots = pod_cfg.keep_episodes
+
+    # Refresh each feed and match against iPod
+    print(f"\n[Podcasts] Refreshing {len(store._feeds)} feed(s)...")
+    refreshed: list[PodcastFeed] = []
+    for feed in store._feeds:
+        print(f"  {feed.feed_url}")
+        try:
+            updated = fetch_feed(feed.feed_url, existing=feed)
+            refreshed.append(updated)
+        except Exception as exc:
+            logger.warning("Feed refresh failed for %s: %s", feed.feed_url, exc)
+            refreshed.append(feed)
+
+    store.update_feeds(refreshed)
+
+    # Build the managed sync plan (handles newest/next mode, slot counts, etc.)
+    plan = build_podcast_managed_plan(refreshed, list(ipod_tracks), store)
+
+    adds = len(getattr(plan, "to_add", []))
+    removes = len(getattr(plan, "to_remove", []))
+    print(f"[Podcasts] Plan: +{adds} add  -{removes} remove")
+
+    if dry_run:
+        print("[Podcasts] Dry run — skipping execution.")
+        return True
+
+    if adds == 0 and removes == 0:
+        print("[Podcasts] Already in sync.")
+        return True
+
+    print("[Podcasts] Executing sync...")
+    engine = SyncEngine()
+    mapping = MappingManager(ipod_path).load()
+    exec_request = EngineRequest(
+        operation=EngineOperation.EXECUTE,
+        ipod_path=ipod_path,
+        ipod_tracks=ipod_tracks,
+        existing_playlists=existing_playlists,
+        plan=plan,
+        mapping=mapping,
+        options=EngineOptions(supports_podcast=True),
+        progress_callback=_progress_cb,
+        device_info=device_info,
+        device_capabilities=device_capabilities,
+    )
+
+    outcome = engine.run(exec_request)
+    if not outcome.success:
+        for d in outcome.diagnostics:
+            if d.fatal:
+                logger.error("Podcast sync failed: %s", d.message)
+        return False
+
+    # Persist updated feed state back to the iPod
+    store.save()
+    print(f"[Podcasts] Done. +{adds} added, -{removes} removed.")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+
+def run_sync(
+    config: SyncConfig,
+    mount_hint: str | None = None,
+    dry_run: bool = False,
+    skip_music: bool = False,
+    skip_podcasts: bool = False,
+) -> int:
+    """Run a full sync cycle. Returns exit code (0 = success)."""
+    from iTunesDB_Parser.ipod_library import load_ipod_library
+
+    # 1. Find iPod
+    print("Scanning for iPod...")
+    result = find_ipod(mount_hint)
+    if result is None:
+        print("No iPod found.", file=sys.stderr)
+        return 1
+
+    device_info, db_path = result
+    mount_path = str(Path(db_path).parent.parent.parent)
+    display = getattr(device_info, "display_name", None) or mount_path
+    caps = getattr(device_info, "capabilities", None)
+    print(f"Found: {display}  [{mount_path}]")
+
+    # 2. Load iTunesDB
+    print("Loading iPod library...")
+    library = load_ipod_library(db_path)
+    if library is None:
+        print("Failed to read iTunesDB.", file=sys.stderr)
+        return 1
+
+    ipod_tracks = tuple(library.get("mhlt", []))
+    existing_playlists = tuple(
+        library.get("mhlp", [])
+        + library.get("mhlp_podcast", [])
+        + library.get("mhlp_smart", [])
+    )
+    print(f"  {len(ipod_tracks)} tracks, {len(existing_playlists)} playlists on iPod")
+
+    ok = True
+
+    # 3. Music sync
+    if not skip_music and config.music_path:
+        ok = run_music_sync(
+            ipod_path=mount_path,
+            ipod_tracks=ipod_tracks,
+            existing_playlists=existing_playlists,
+            device_info=device_info,
+            device_capabilities=caps,
+            config=config,
+            dry_run=dry_run,
+        ) and ok
+
+    # 4. Podcast sync
+    if not skip_podcasts and config.podcasts:
+        ok = run_podcast_sync(
+            ipod_path=mount_path,
+            ipod_tracks=ipod_tracks,
+            existing_playlists=existing_playlists,
+            device_info=device_info,
+            device_capabilities=caps,
+            config=config,
+            dry_run=dry_run,
+        ) and ok
+
+    return 0 if ok else 1

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,32 @@
+# iopenpod-sync configuration
+# Copy to ~/.config/iopenpodcli/config.yaml and edit.
+# Run `iopenpod-sync --init-config` to write this file automatically.
+
+# Root directory containing your music files.
+# The engine scans recursively for audio files here.
+music_path: ~/Music
+
+# Playlist files to sync (M3U / M3U8 / PLS / XSPF).
+# Paths are relative to music_path unless absolute.
+# Leave empty [] to sync all discovered music.
+playlists:
+  - Favorites.m3u
+  - Workout.m3u8
+
+# Podcast feeds.  State (episode status, download paths) is stored on the
+# iPod itself at /iPod_Control/iOpenPodPodcasts/ so it follows the device.
+podcasts:
+  - url: https://feeds.simplecast.com/4T39_jAj   # Darknet Diaries
+    keep_episodes: 3
+  - url: https://feeds.transistor.fm/some-show
+    keep_episodes: 5
+
+# Pull ratings (0–5 stars) from iPod back to local file tags after sync.
+pull_ratings: true
+
+# Pull play counts from iPod back to local file tags after sync.
+pull_playcounts: true
+
+# How to resolve a rating conflict between iPod and PC file tags.
+# Options: ipod_wins | pc_wins | higher_wins
+rating_strategy: ipod_wins

--- a/launchd/com.tristonyoder.iopenpod-sync.plist
+++ b/launchd/com.tristonyoder.iopenpod-sync.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Auto-sync iPod when it mounts.
+
+  Install:
+    cp com.tristonyoder.iopenpod-sync.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.tristonyoder.iopenpod-sync.plist
+
+  The WatchPaths entry triggers this agent whenever the /Volumes directory
+  changes (i.e. a volume mounts or unmounts).  The sync script detects whether
+  an iPod is present and exits cleanly if not.
+
+  Adjust the ProgramArguments path to wherever iopenpod-sync is installed.
+  With a uv/pipx install it will be in ~/.local/bin/iopenpod-sync.
+  With Nix it will be in your PATH via the nix package.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tristonyoder.iopenpod-sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <!-- Wait 3 s for the iPod filesystem to settle after mount, then sync -->
+        <string>sleep 3 &amp;&amp; /Users/tyoder/.local/bin/iopenpod-sync 2&gt;&gt;/tmp/iopenpod-sync.log</string>
+    </array>
+
+    <!-- Fire whenever /Volumes changes (volume mounted or unmounted) -->
+    <key>WatchPaths</key>
+    <array>
+        <string>/Volumes</string>
+    </array>
+
+    <!-- Throttle: don't re-trigger within 10 s of the last run -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/iopenpod-sync.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/iopenpod-sync.log</string>
+</dict>
+</plist>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,12 @@ dependencies = [
     "packaging>=23.0",
     "tqdm>=4.67.3",
     "python-dateutil>=2.9.0.post0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]
 iopenpod = "main:main"
+iopenpod-sync = "cli.main:main"
 
 [dependency-groups]
 dev = [
@@ -61,6 +63,7 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 only-include = [
+    "cli",
     "app_core",
     "infrastructure",
     "main.py",


### PR DESCRIPTION
## Summary

- Adds `iopod` — a headless CLI for syncing an iPod from music playlists, downloading podcasts, and pulling ratings/playcounts back to PC tags
- Two-phase staging architecture: `iopod prepare` runs on a timer to pre-fingerprint playlist tracks and download podcast episodes; `iopod sync` runs fast on iPod connect using the pre-built manifest
- When playlists are configured, the sync engine scans only playlist files (not the full music library), so the iPod contains exactly the configured playlist tracks — nothing more, nothing less
- ffmpeg included in runtime PATH for audio transcoding (FLAC→AAC for iPod Classic)
- Headless build strips Qt dependency for server/systemd deployment

## Key fixes

- `DeviceInfo.path` not `mount_path` (field renamed upstream)
- Synthesise minimal `DeviceInfo` when `--device` path is outside scanner search dirs
- Playlist-only `pc_folders` scope was tried and rejected: narrowing caused the diff engine to treat all out-of-scope iPod tracks as "removed from PC" and delete them. Full music path scan is always used; the fingerprint cache from `prepare` speeds up the identify step.
- `media_types=("playlists",)` is the correct way to limit iPod contents to playlist tracks — the planning stage resolves audio tracks from m3u references, keeping removals correct