### PR TITLE
Add online artwork search to the track editor (iTunes + Cover Art Archive)

### DIFF
--- a/src/iopenpod/artwork_search/__init__.py
+++ b/src/iopenpod/artwork_search/__init__.py
@@ -1,0 +1,3 @@
+"""Keyless online album-artwork lookup (iTunes Search API, Cover Art Archive)."""
+
+from __future__ import annotations

--- a/src/iopenpod/artwork_search/coverart.py
+++ b/src/iopenpod/artwork_search/coverart.py
@@ -122,6 +122,25 @@ def _candidate_for(release_group: dict) -> ArtworkCandidate | None:
         )
         response.raise_for_status()
         payload = response.json()
+
+        for image in payload.get("images", []):
+            if not image.get("front"):
+                continue
+            thumbnails = image.get("thumbnails") or {}
+            original = str(image.get("image") or "").strip()
+            full_url = _pick(thumbnails, _FULL_KEYS) or original
+            thumb_url = _pick(thumbnails, _THUMB_KEYS) or full_url
+            if not full_url:
+                continue
+            return ArtworkCandidate(
+                title=str(release_group.get("title") or "").strip(),
+                artist=_artist_of(release_group),
+                source=SOURCE_NAME,
+                thumb_url=thumb_url,
+                full_url=full_url,
+                year=str(release_group.get("first-release-date") or "")[:4],
+            )
+        return None
     except requests.HTTPError as exc:
         # 404 with an HTML body is the normal "this release has no art" answer.
         status = getattr(getattr(exc, "response", None), "status_code", None)
@@ -129,28 +148,12 @@ def _candidate_for(release_group: dict) -> ArtworkCandidate | None:
             return None
         log.debug("Cover Art Archive lookup failed for %s: %s", mbid, exc)
         return None
-    except (requests.RequestException, ValueError) as exc:
+    except (requests.RequestException, ValueError, AttributeError, TypeError, KeyError) as exc:
+        # Covers both transport/JSON failures and an unexpected payload shape
+        # (e.g. a non-dict images entry) — either way, skip this one release
+        # group without aborting the others.
         log.debug("Cover Art Archive lookup failed for %s: %s", mbid, exc)
         return None
-
-    for image in payload.get("images", []):
-        if not image.get("front"):
-            continue
-        thumbnails = image.get("thumbnails") or {}
-        original = str(image.get("image") or "").strip()
-        full_url = _pick(thumbnails, _FULL_KEYS) or original
-        thumb_url = _pick(thumbnails, _THUMB_KEYS) or full_url
-        if not full_url:
-            continue
-        return ArtworkCandidate(
-            title=str(release_group.get("title") or "").strip(),
-            artist=_artist_of(release_group),
-            source=SOURCE_NAME,
-            thumb_url=thumb_url,
-            full_url=full_url,
-            year=str(release_group.get("first-release-date") or "")[:4],
-        )
-    return None
 
 
 def search(seed: SeedQuery, limit: int = 8) -> list[ArtworkCandidate]:

--- a/src/iopenpod/artwork_search/coverart.py
+++ b/src/iopenpod/artwork_search/coverart.py
@@ -1,0 +1,170 @@
+"""MusicBrainz + Cover Art Archive artwork provider. No authentication required."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+from .download import HTTP_TIMEOUT, user_agent
+from .errors import ArtworkErrorInfo, ArtworkSearchError
+from .models import ArtworkCandidate
+from .query import SeedQuery, lucene_release_group_query
+
+log = logging.getLogger(__name__)
+
+SOURCE_NAME = "Cover Art Archive"
+
+_MB_URL = "https://musicbrainz.org/ws/2/release-group/"
+_CAA_URL = "https://coverartarchive.org/release-group"
+
+# MusicBrainz terms of service: at most one request per second, and a
+# descriptive User-Agent. Violating either gets the application IP-blocked.
+MB_RATE_LIMIT_SECONDS = 1.0
+
+_CAA_WORKERS = 4
+_THUMB_KEYS = ("250", "small")
+_FULL_KEYS = ("1200", "500", "large")
+
+_rate_lock = threading.Lock()
+_last_mb_request = 0.0
+
+
+def _throttle_musicbrainz() -> None:
+    """Block until at least MB_RATE_LIMIT_SECONDS since the last MB request."""
+    global _last_mb_request
+    with _rate_lock:
+        elapsed = time.monotonic() - _last_mb_request
+        wait = MB_RATE_LIMIT_SECONDS - elapsed
+        if wait > 0:
+            time.sleep(wait)
+        _last_mb_request = time.monotonic()
+
+
+def _artist_of(release_group: dict) -> str:
+    parts = []
+    for credit in release_group.get("artist-credit", []):
+        if isinstance(credit, dict):
+            parts.append(str(credit.get("name") or ""))
+        elif isinstance(credit, str):
+            parts.append(credit)
+    return "".join(parts).strip()
+
+
+def _search_release_groups(seed: SeedQuery, limit: int) -> list[dict]:
+    params = {
+        "query": lucene_release_group_query(seed),
+        "fmt": "json",
+        "limit": max(1, min(limit, 25)),
+    }
+    _throttle_musicbrainz()
+    try:
+        response = requests.get(
+            _MB_URL,
+            params=params,
+            timeout=HTTP_TIMEOUT,
+            headers={"User-Agent": user_agent()},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except requests.RequestException as exc:
+        log.warning("MusicBrainz search failed: %s", exc)
+        raise ArtworkSearchError(
+            ArtworkErrorInfo(
+                title="MusicBrainz did not answer",
+                message="iOpenPod could not reach the MusicBrainz service.",
+            )
+        ) from exc
+    except ValueError as exc:
+        log.warning("MusicBrainz returned unreadable JSON: %s", exc)
+        raise ArtworkSearchError(
+            ArtworkErrorInfo(
+                title="MusicBrainz answered strangely",
+                message="The MusicBrainz service answered, but iOpenPod could not read the results.",
+            )
+        ) from exc
+
+    # MusicBrainz reports overload in the body, not the status line.
+    if isinstance(payload, dict) and payload.get("error"):
+        log.info("MusicBrainz reported an error body: %s", payload.get("error"))
+        raise ArtworkSearchError(
+            ArtworkErrorInfo(
+                title="MusicBrainz is busy",
+                message="The MusicBrainz service is busy right now. Try again in a moment.",
+            )
+        )
+
+    return list(payload.get("release-groups", []))
+
+
+def _pick(thumbnails: dict, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = str(thumbnails.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _candidate_for(release_group: dict) -> ArtworkCandidate | None:
+    """Look up cover art for one release group, or None when it has none."""
+    mbid = str(release_group.get("id") or "").strip()
+    if not mbid:
+        return None
+
+    try:
+        response = requests.get(
+            f"{_CAA_URL}/{mbid}",
+            timeout=HTTP_TIMEOUT,
+            headers={"User-Agent": user_agent()},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except requests.HTTPError as exc:
+        # 404 with an HTML body is the normal "this release has no art" answer.
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            return None
+        log.debug("Cover Art Archive lookup failed for %s: %s", mbid, exc)
+        return None
+    except (requests.RequestException, ValueError) as exc:
+        log.debug("Cover Art Archive lookup failed for %s: %s", mbid, exc)
+        return None
+
+    for image in payload.get("images", []):
+        if not image.get("front"):
+            continue
+        thumbnails = image.get("thumbnails") or {}
+        original = str(image.get("image") or "").strip()
+        full_url = _pick(thumbnails, _FULL_KEYS) or original
+        thumb_url = _pick(thumbnails, _THUMB_KEYS) or full_url
+        if not full_url:
+            continue
+        return ArtworkCandidate(
+            title=str(release_group.get("title") or "").strip(),
+            artist=_artist_of(release_group),
+            source=SOURCE_NAME,
+            thumb_url=thumb_url,
+            full_url=full_url,
+            year=str(release_group.get("first-release-date") or "")[:4],
+        )
+    return None
+
+
+def search(seed: SeedQuery, limit: int = 8) -> list[ArtworkCandidate]:
+    """Find cover art via MusicBrainz release groups and the Cover Art Archive."""
+    if not seed.text.strip():
+        return []
+
+    release_groups = _search_release_groups(seed, limit)
+    if not release_groups:
+        return []
+
+    # Cover Art Archive is a separate host and is not covered by the
+    # MusicBrainz rate limit, so these lookups may run concurrently.
+    with ThreadPoolExecutor(max_workers=_CAA_WORKERS) as pool:
+        found = list(pool.map(_candidate_for, release_groups))
+
+    return [candidate for candidate in found if candidate is not None]

--- a/src/iopenpod/artwork_search/download.py
+++ b/src/iopenpod/artwork_search/download.py
@@ -77,7 +77,7 @@ def fetch_image(url: str) -> bytes:
                 if total > MAX_IMAGE_BYTES:
                     raise _fail(
                         "That image is too large",
-                        f"That image is too large. Artwork must be smaller than {MAX_IMAGE_BYTES // (1024 * 1024)} MB.",
+                        f"Artwork must be smaller than {MAX_IMAGE_BYTES // (1024 * 1024)} MB.",
                     )
                 chunks.append(chunk)
     except requests.TooManyRedirects as exc:

--- a/src/iopenpod/artwork_search/download.py
+++ b/src/iopenpod/artwork_search/download.py
@@ -1,0 +1,118 @@
+"""Guarded image fetching shared by every artwork source."""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tempfile
+from urllib.parse import urlparse
+
+import requests
+from PIL import Image, UnidentifiedImageError
+
+from iopenpod.infrastructure.version import get_version
+
+from .errors import ArtworkErrorInfo, ArtworkSearchError
+
+log = logging.getLogger(__name__)
+
+HTTP_TIMEOUT = 15
+MAX_REDIRECTS = 5
+MAX_IMAGE_BYTES = 20 * 1024 * 1024
+TEMP_PREFIX = "iopenpod-artwork-"
+CONTACT_URL = "https://github.com/TheRealSavi/iOpenPod"
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def user_agent() -> str:
+    """MusicBrainz requires a descriptive agent naming the app and a contact URL."""
+    return f"iOpenPod/{get_version()} ( {CONTACT_URL} )"
+
+
+def _fail(title: str, message: str) -> ArtworkSearchError:
+    return ArtworkSearchError(ArtworkErrorInfo(title=title, message=message))
+
+
+def fetch_image(url: str) -> bytes:
+    """Download an image, refusing anything that violates a guard.
+
+    Raises ArtworkSearchError with user-facing copy on every rejection.
+    """
+    url = (url or "").strip()
+    if not url:
+        raise _fail("No image address", "Enter an image address first.")
+
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise _fail(
+            "That address will not work",
+            "Artwork can only be loaded from a http:// or https:// address.",
+        )
+
+    session = requests.Session()
+    session.max_redirects = MAX_REDIRECTS
+    try:
+        with session.get(
+            url,
+            timeout=HTTP_TIMEOUT,
+            stream=True,
+            headers={"User-Agent": user_agent()},
+        ) as response:
+            response.raise_for_status()
+            content_type = str(response.headers.get("Content-Type", "")).lower()
+            if not content_type.startswith("image/"):
+                raise _fail(
+                    "That address is not an image",
+                    f"The server answered with {content_type or 'an unknown type'} instead of an image.",
+                )
+
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > MAX_IMAGE_BYTES:
+                    raise _fail(
+                        "That image is too large",
+                        f"That image is too large. Artwork must be smaller than {MAX_IMAGE_BYTES // (1024 * 1024)} MB.",
+                    )
+                chunks.append(chunk)
+    except requests.TooManyRedirects as exc:
+        raise _fail(
+            "That address redirected too many times",
+            "The image address kept forwarding somewhere else. Try a direct link to the image.",
+        ) from exc
+    finally:
+        session.close()
+
+    data = b"".join(chunks)
+    try:
+        with Image.open(io.BytesIO(data)) as probe:
+            probe.verify()
+    except (OSError, UnidentifiedImageError) as exc:
+        log.debug("Rejected artwork payload from %s", url, exc_info=True)
+        raise _fail(
+            "That image could not be read",
+            "The download finished, but the file was not a readable image.",
+        ) from exc
+
+    return data
+
+
+def save_temp_image(data: bytes) -> str:
+    """Write image bytes to a temp file the app knows how to clean up."""
+    fd, path = tempfile.mkstemp(prefix=TEMP_PREFIX, suffix=".png")
+    os.close(fd)
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            image.convert("RGB").save(path, "PNG")
+    except Exception:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        raise
+    return path

--- a/src/iopenpod/artwork_search/download.py
+++ b/src/iopenpod/artwork_search/download.py
@@ -85,6 +85,33 @@ def fetch_image(url: str) -> bytes:
             "That address redirected too many times",
             "The image address kept forwarding somewhere else. Try a direct link to the image.",
         ) from exc
+    except requests.HTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        code = f"HTTP {status}" if isinstance(status, int) else ""
+        if isinstance(status, int) and 400 <= status < 500:
+            raise ArtworkSearchError(
+                ArtworkErrorInfo(
+                    title="That image is not available",
+                    message="The server refused the request, or the image has moved or been removed.",
+                    code=code,
+                )
+            ) from exc
+        raise ArtworkSearchError(
+            ArtworkErrorInfo(
+                title="The image server is having trouble",
+                message="The server answered with an error. This usually clears up after a little while.",
+                code=code,
+            )
+        ) from exc
+    except requests.RequestException as exc:
+        # Timeouts, DNS and connection failures. Without this the docstring's
+        # promise is false and a caller catching only ArtworkSearchError
+        # propagates a raw requests exception.
+        log.debug("Artwork download failed for %s", url, exc_info=True)
+        raise _fail(
+            "Could not reach that image",
+            "iOpenPod could not download the image. Check your connection and try again.",
+        ) from exc
     finally:
         session.close()
 

--- a/src/iopenpod/artwork_search/errors.py
+++ b/src/iopenpod/artwork_search/errors.py
@@ -1,0 +1,66 @@
+"""Friendly artwork-search network error descriptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import requests
+
+
+@dataclass(frozen=True)
+class ArtworkErrorInfo:
+    title: str
+    message: str
+    code: str = ""
+
+
+class ArtworkSearchError(RuntimeError):
+    """Network or provider failure with user-facing title/message/code."""
+
+    def __init__(self, info: ArtworkErrorInfo):
+        super().__init__(info.message)
+        self.info = info
+
+
+def describe_artwork_error(
+    error: BaseException,
+    *,
+    action: str = "search for artwork",
+) -> ArtworkErrorInfo:
+    """Return short, user-facing copy for an artwork network failure."""
+    if isinstance(error, ArtworkSearchError):
+        return error.info
+
+    if isinstance(error, requests.Timeout):
+        return ArtworkErrorInfo(
+            title="The connection timed out",
+            message="The artwork service took too long to answer. Try again in a moment.",
+        )
+
+    if isinstance(error, requests.ConnectionError):
+        return ArtworkErrorInfo(
+            title="No internet connection",
+            message="iOpenPod could not reach the artwork service. Check your connection and try again.",
+        )
+
+    if isinstance(error, requests.HTTPError):
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if isinstance(status_code, int):
+            code = f"HTTP {status_code}"
+            if 400 <= status_code < 500:
+                return ArtworkErrorInfo(
+                    title="The artwork service rejected the request",
+                    message="The service refused this search, or the image has moved. The code below can help identify the issue.",
+                    code=code,
+                )
+            return ArtworkErrorInfo(
+                title="The artwork service is having trouble",
+                message="The server answered with an error. This usually clears up after a little while.",
+                code=code,
+            )
+
+    return ArtworkErrorInfo(
+        title="Something went wrong",
+        message=f"iOpenPod could not {action}. Try again in a moment.",
+    )

--- a/src/iopenpod/artwork_search/itunes.py
+++ b/src/iopenpod/artwork_search/itunes.py
@@ -1,0 +1,95 @@
+"""iTunes Search API artwork provider. No authentication required."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import requests
+
+from .download import HTTP_TIMEOUT, user_agent
+from .errors import ArtworkErrorInfo, ArtworkSearchError
+from .models import ArtworkCandidate
+from .query import SeedQuery
+
+log = logging.getLogger(__name__)
+
+SOURCE_NAME = "iTunes"
+
+_SEARCH_URL = "https://itunes.apple.com/search"
+_THUMB_SIZE = 250
+_FULL_SIZE = 1200
+
+# Matches the trailing "/100x100bb.jpg" size segment of an mzstatic artwork URL.
+_SIZE_SEGMENT = re.compile(r"/\d+x\d+bb\.(jpg|png)$", re.IGNORECASE)
+
+
+def artwork_url_at_size(url: str, size: int) -> str:
+    """Rewrite an mzstatic artwork URL to request a different resolution.
+
+    The service clamps to the source resolution rather than failing, so asking
+    for more pixels than exist is safe. A URL that does not have the expected
+    size segment is returned unchanged.
+    """
+    if not url or not _SIZE_SEGMENT.search(url):
+        return url
+    return _SIZE_SEGMENT.sub(f"/{size}x{size}bb.jpg", url)
+
+
+def search(seed: SeedQuery, limit: int = 24) -> list[ArtworkCandidate]:
+    """Search the iTunes album catalogue for cover art."""
+    term = seed.text.strip()
+    if not term:
+        return []
+
+    params = {
+        "term": term,
+        "media": "music",
+        "entity": "album",
+        "limit": max(1, min(limit, 200)),
+        "country": "US",
+    }
+
+    try:
+        response = requests.get(
+            _SEARCH_URL,
+            params=params,
+            timeout=HTTP_TIMEOUT,
+            headers={"User-Agent": user_agent()},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except requests.RequestException as exc:
+        log.warning("iTunes artwork search failed: %s", exc)
+        raise ArtworkSearchError(
+            ArtworkErrorInfo(
+                title="iTunes did not answer",
+                message="iOpenPod could not reach the iTunes artwork service.",
+            )
+        ) from exc
+    except ValueError as exc:
+        log.warning("iTunes artwork search returned unreadable JSON: %s", exc)
+        raise ArtworkSearchError(
+            ArtworkErrorInfo(
+                title="iTunes answered strangely",
+                message="The iTunes service answered, but iOpenPod could not read the results.",
+            )
+        ) from exc
+
+    candidates: list[ArtworkCandidate] = []
+    for entry in payload.get("results", []):
+        art_url = str(entry.get("artworkUrl100") or "").strip()
+        if not art_url:
+            continue
+        candidates.append(
+            ArtworkCandidate(
+                title=str(entry.get("collectionName") or "").strip(),
+                artist=str(entry.get("artistName") or "").strip(),
+                source=SOURCE_NAME,
+                thumb_url=artwork_url_at_size(art_url, _THUMB_SIZE),
+                full_url=artwork_url_at_size(art_url, _FULL_SIZE),
+                year=str(entry.get("releaseDate") or "")[:4],
+                width=_FULL_SIZE,
+            )
+        )
+    return candidates

--- a/src/iopenpod/artwork_search/models.py
+++ b/src/iopenpod/artwork_search/models.py
@@ -1,0 +1,30 @@
+"""Data model for a single online artwork search result."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ArtworkCandidate:
+    """One cover image offered by a provider.
+
+    ``thumb_url`` is a small image for the result grid; ``full_url`` is the
+    high-resolution image downloaded only when the user picks this candidate.
+    """
+
+    title: str
+    artist: str
+    source: str
+    thumb_url: str
+    full_url: str
+    year: str = ""
+    width: int = 0
+
+    @property
+    def detail_line(self) -> str:
+        """Short ``year · source · width`` summary for the result card."""
+        parts = [part for part in (self.year, self.source) if part]
+        if self.width:
+            parts.append(f"{self.width}px")
+        return "  ·  ".join(parts)

--- a/src/iopenpod/artwork_search/models.py
+++ b/src/iopenpod/artwork_search/models.py
@@ -27,4 +27,5 @@ class ArtworkCandidate:
         parts = [part for part in (self.year, self.source) if part]
         if self.width:
             parts.append(f"{self.width}px")
-        return "  ·  ".join(parts)
+        # Tight separator: this has to fit one fixed-width card row.
+        return " · ".join(parts)

--- a/src/iopenpod/artwork_search/query.py
+++ b/src/iopenpod/artwork_search/query.py
@@ -30,9 +30,19 @@ def _shared(tracks: list[dict], key: str) -> str:
 def seed_query_from_tracks(tracks: list[dict]) -> SeedQuery:
     """Pre-fill the search box from the selected tracks.
 
-    All tracks share an album  -> album artist + album, fielded.
-    Single track, no album     -> artist + title, fielded on artist only.
-    Anything else              -> empty.
+    All tracks share Album Artist (or Artist) and Album -> "{artist} {album}",
+        fielded: both artist and album are known, so
+        ``lucene_release_group_query`` can build ``releasegroup:… AND
+        artist:…``.
+    Album known but no resolvable artist (single track with no artist, or
+        multiple tracks that share an Album but disagree on artist) ->
+        the album name alone, still fielded on album (searching the album is
+        strictly better than an empty box or a bare track title).
+    Single track, no shared album, with a title -> "{artist} {title}" or the
+        bare title. This is always sent as free text, never fielded:
+        ``lucene_release_group_query`` only fields a query when both artist
+        and album are set, and a track title is not a release-group title.
+    Anything else -> empty.
     """
     if not tracks:
         return SeedQuery(text="")
@@ -42,6 +52,9 @@ def seed_query_from_tracks(tracks: list[dict]) -> SeedQuery:
 
     if album and artist:
         return SeedQuery(text=f"{artist} {album}", artist=artist, album=album)
+
+    if album:
+        return SeedQuery(text=album, album=album)
 
     if len(tracks) == 1:
         title = _field(tracks[0], "Title")

--- a/src/iopenpod/artwork_search/query.py
+++ b/src/iopenpod/artwork_search/query.py
@@ -1,0 +1,70 @@
+"""Build artwork search queries from a track selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SeedQuery:
+    """A pre-filled search box value, plus its separated parts when known."""
+
+    text: str
+    artist: str = ""
+    album: str = ""
+
+
+def _field(track: dict, key: str) -> str:
+    return str(track.get(key) or "").strip()
+
+
+def _shared(tracks: list[dict], key: str) -> str:
+    """Return the common value for ``key``, or "" when tracks disagree."""
+    values = {_field(track, key) for track in tracks}
+    if len(values) != 1:
+        return ""
+    value = values.pop()
+    return value
+
+
+def seed_query_from_tracks(tracks: list[dict]) -> SeedQuery:
+    """Pre-fill the search box from the selected tracks.
+
+    All tracks share an album  -> album artist + album, fielded.
+    Single track, no album     -> artist + title, fielded on artist only.
+    Anything else              -> empty.
+    """
+    if not tracks:
+        return SeedQuery(text="")
+
+    album = _shared(tracks, "Album")
+    artist = _shared(tracks, "Album Artist") or _shared(tracks, "Artist")
+
+    if album and artist:
+        return SeedQuery(text=f"{artist} {album}", artist=artist, album=album)
+
+    if len(tracks) == 1:
+        title = _field(tracks[0], "Title")
+        single_artist = _field(tracks[0], "Album Artist") or _field(tracks[0], "Artist")
+        if single_artist and title:
+            return SeedQuery(text=f"{single_artist} {title}", artist=single_artist)
+        if title:
+            return SeedQuery(text=title)
+
+    return SeedQuery(text="")
+
+
+def escape_lucene(value: str) -> str:
+    """Escape the characters that break a quoted Lucene phrase."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def lucene_release_group_query(seed: SeedQuery) -> str:
+    """Build the MusicBrainz release-group query.
+
+    A fielded query is dramatically more relevant than free text, so use one
+    whenever the artist and album are separable.
+    """
+    if seed.artist and seed.album:
+        return f'releasegroup:"{escape_lucene(seed.album)}" AND artist:"{escape_lucene(seed.artist)}"'
+    return seed.text

--- a/src/iopenpod/gui/widgets/artworkSearchDialog.py
+++ b/src/iopenpod/gui/widgets/artworkSearchDialog.py
@@ -43,8 +43,9 @@ from .podcastStates import PodcastStatePanel
 log = logging.getLogger(__name__)
 
 MAX_RESULTS = 24
-GRID_COLUMNS = 3
 THUMB_SIZE = 140
+GRID_SPACING = 10
+MIN_GRID_COLUMNS = 1
 
 # Every card is exactly the same size, so a result arriving late can never
 # move a card the user is already reaching for.
@@ -75,6 +76,15 @@ def _card_metrics() -> tuple[int, int]:
         )
         _card_metrics_cache = (line, height)
     return _card_metrics_cache
+
+
+def columns_for_width(width: int) -> int:
+    """How many fixed-width cards fit in ``width`` pixels of viewport.
+
+    ``n`` cards occupy ``n * CARD_WIDTH + (n - 1) * GRID_SPACING``, which
+    rearranges to the expression below.
+    """
+    return max(MIN_GRID_COLUMNS, (width + GRID_SPACING) // (CARD_WIDTH + GRID_SPACING))
 
 
 def _provider_modules():
@@ -114,6 +124,11 @@ class ArtworkSearchDialog(QDialog):
         self._candidates: list[ArtworkCandidate] = []
         self._seen_urls: set[str] = set()
         self._source_counts: dict[str, int] = {}
+        # Cards are kept so a resize can re-place them at a new column count
+        # without destroying already-loaded thumbnails. Column count is
+        # recomputed from the viewport width on show and on every resize.
+        self._cards: list[QWidget] = []
+        self._columns = MIN_GRID_COLUMNS
         self._failed_providers: list[str] = []
         self._first_failure_info = None
         self._pending_providers = 0
@@ -217,11 +232,8 @@ class ArtworkSearchDialog(QDialog):
         self._grid_host.setStyleSheet("background: transparent;")
         self._grid = QGridLayout(self._grid_host)
         self._grid.setContentsMargins(0, 0, 0, 0)
-        self._grid.setSpacing(10)
-        # Absorb leftover width in a phantom trailing column, otherwise the
-        # grid spreads it across the occupied columns and a lone result
-        # stretches to the full viewport.
-        self._grid.setColumnStretch(GRID_COLUMNS, 1)
+        self._grid.setSpacing(GRID_SPACING)
+        self._apply_column_stretch()
         self._outer_layout.addWidget(self._grid_host)
         self._outer_layout.addStretch()
 
@@ -232,6 +244,7 @@ class ArtworkSearchDialog(QDialog):
             }}
         """)
         scroll.setWidget(self._results_container)
+        self._scroll = scroll
         layout.addWidget(scroll, stretch=1)
 
         url_row = QHBoxLayout()
@@ -449,6 +462,7 @@ class ArtworkSearchDialog(QDialog):
         self._candidates = []
         self._seen_urls = set()
         self._source_counts = {}
+        self._cards = []
         while self._grid.count():
             item = self._grid.takeAt(0)
             widget = item.widget() if item is not None else None
@@ -458,12 +472,74 @@ class ArtworkSearchDialog(QDialog):
     def _add_card(self, candidate: ArtworkCandidate, index: int) -> None:
         card = _ArtworkResultCard(candidate, self, load_thumbnail=self._load_thumbnails)
         card.picked.connect(self._on_pick)
+        self._cards.append(card)
+        self._place_card(card, index)
+
+    # ── Responsive grid ──────────────────────────────────────────────────
+
+    def grid_columns(self) -> int:
+        """Cards per row at the dialog's current width."""
+        return self._columns
+
+    def _viewport_width(self) -> int:
+        scroll = getattr(self, "_scroll", None)
+        if scroll is None:
+            return CARD_WIDTH
+        return scroll.viewport().width()
+
+    def _place_card(self, card: QWidget, index: int) -> None:
         self._grid.addWidget(
             card,
-            index // GRID_COLUMNS,
-            index % GRID_COLUMNS,
+            index // self._columns,
+            index % self._columns,
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop,
         )
+
+    def _apply_column_stretch(self) -> None:
+        """Send leftover width to a phantom trailing column.
+
+        Without this the grid spreads the slack across the occupied columns
+        and a lone result stretches to the full viewport.
+        """
+        for column in range(self._grid.columnCount() + 2):
+            self._grid.setColumnStretch(column, 0)
+        self._grid.setColumnStretch(self._columns, 1)
+
+    def _reflow_grid(self) -> None:
+        """Re-place the existing cards at the current column count.
+
+        Detaches rather than deletes, so already-loaded thumbnails survive
+        a resize.
+        """
+        while self._grid.count():
+            self._grid.takeAt(0)
+        for index, card in enumerate(self._cards):
+            self._place_card(card, index)
+        self._apply_column_stretch()
+        # A narrower grid needs more rows, but the layout's cached size hint
+        # still describes the old row count — without invalidating it the host
+        # keeps its previous height and the fixed-height cards are crushed
+        # into overlapping rows.
+        self._grid.invalidate()
+        self._grid_host.updateGeometry()
+        self._results_container.adjustSize()
+
+    def _sync_columns_to_width(self) -> None:
+        columns = columns_for_width(self._viewport_width())
+        if columns == self._columns:
+            return
+        self._columns = columns
+        self._reflow_grid()
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        super().resizeEvent(event)
+        # Guarded by the equality check in _sync_columns_to_width, so the
+        # relayout this may trigger cannot recurse.
+        self._sync_columns_to_width()
+
+    def showEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        super().showEvent(event)
+        self._sync_columns_to_width()
 
     # ── Picking ──────────────────────────────────────────────────────────
 

--- a/src/iopenpod/gui/widgets/artworkSearchDialog.py
+++ b/src/iopenpod/gui/widgets/artworkSearchDialog.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import logging
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QFont, QImage, QPixmap
+from PyQt6.QtCore import QRect, Qt, pyqtSignal
+from PyQt6.QtGui import QFont, QFontMetrics, QImage, QPixmap
 from PyQt6.QtWidgets import (
     QDialog,
     QFrame,
@@ -45,6 +45,36 @@ log = logging.getLogger(__name__)
 MAX_RESULTS = 24
 GRID_COLUMNS = 3
 THUMB_SIZE = 140
+
+# Every card is exactly the same size, so a result arriving late can never
+# move a card the user is already reaching for.
+_CARD_PADDING = 8
+_CARD_SPACING = 4
+_TITLE_LINES = 2
+_TEXT_ROWS = _TITLE_LINES + 2  # title lines, then artist and detail
+CARD_WIDTH = THUMB_SIZE + _CARD_PADDING * 2
+
+_card_metrics_cache: tuple[int, int] | None = None
+
+
+def _card_metrics() -> tuple[int, int]:
+    """Return ``(line_height, card_height)`` for a result card.
+
+    Derived from font metrics rather than hardcoded so the grid stays
+    uniform across themes and display scales. Cached because every card
+    uses the same font and must therefore be the same height.
+    """
+    global _card_metrics_cache
+    if _card_metrics_cache is None:
+        line = QFontMetrics(QFont(FONT_FAMILY, Metrics.FONT_SM)).height()
+        height = (
+            _CARD_PADDING * 2          # top and bottom padding
+            + THUMB_SIZE               # thumbnail
+            + _CARD_SPACING * 3        # gaps between the four rows
+            + line * _TEXT_ROWS        # title (2 lines), artist, detail
+        )
+        _card_metrics_cache = (line, height)
+    return _card_metrics_cache
 
 
 def _provider_modules():
@@ -167,6 +197,9 @@ class ArtworkSearchDialog(QDialog):
         layout.addWidget(self._status_label)
 
         self._results_container = QWidget()
+        # Fixed-size cards no longer cover the whole viewport, so these hosts
+        # must be transparent or their unthemed default paints beside the grid.
+        self._results_container.setStyleSheet("background: transparent;")
         self._outer_layout = QVBoxLayout(self._results_container)
         self._outer_layout.setContentsMargins(0, 0, 0, 0)
         self._outer_layout.setSpacing(8)
@@ -181,9 +214,14 @@ class ArtworkSearchDialog(QDialog):
         self._outer_layout.addWidget(self._state_panel)
 
         self._grid_host = QWidget()
+        self._grid_host.setStyleSheet("background: transparent;")
         self._grid = QGridLayout(self._grid_host)
         self._grid.setContentsMargins(0, 0, 0, 0)
         self._grid.setSpacing(10)
+        # Absorb leftover width in a phantom trailing column, otherwise the
+        # grid spreads it across the occupied columns and a lone result
+        # stretches to the full viewport.
+        self._grid.setColumnStretch(GRID_COLUMNS, 1)
         self._outer_layout.addWidget(self._grid_host)
         self._outer_layout.addStretch()
 
@@ -420,7 +458,12 @@ class ArtworkSearchDialog(QDialog):
     def _add_card(self, candidate: ArtworkCandidate, index: int) -> None:
         card = _ArtworkResultCard(candidate, self, load_thumbnail=self._load_thumbnails)
         card.picked.connect(self._on_pick)
-        self._grid.addWidget(card, index // GRID_COLUMNS, index % GRID_COLUMNS)
+        self._grid.addWidget(
+            card,
+            index // GRID_COLUMNS,
+            index % GRID_COLUMNS,
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop,
+        )
 
     # ── Picking ──────────────────────────────────────────────────────────
 
@@ -506,6 +549,15 @@ class _ArtworkResultCard(QFrame):
         super().__init__(parent)
         self._candidate = candidate
         self.setCursor(Qt.CursorShape.PointingHandCursor)
+        line_height, card_height = _card_metrics()
+        self.setFixedSize(CARD_WIDTH, card_height)
+        # Rows are elided to fit the fixed card, so the tooltip carries the
+        # full text — nothing is only visible when a title happens to be short.
+        tooltip = "\n".join(
+            part for part in (candidate.title, candidate.artist, candidate.detail_line) if part
+        )
+        if tooltip:
+            self.setToolTip(tooltip)
         self.setStyleSheet(f"""
             _ArtworkResultCard {{
                 background: {paint_css('surface.inset')};
@@ -518,8 +570,8 @@ class _ArtworkResultCard(QFrame):
         """)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(4)
+        layout.setContentsMargins(_CARD_PADDING, _CARD_PADDING, _CARD_PADDING, _CARD_PADDING)
+        layout.setSpacing(_CARD_SPACING)
 
         self._art_label = QLabel()
         self._art_label.setFixedSize(THUMB_SIZE, THUMB_SIZE)
@@ -531,22 +583,70 @@ class _ArtworkResultCard(QFrame):
         """)
         layout.addWidget(self._art_label, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        title = make_label(candidate.title, size=Metrics.FONT_SM, weight=QFont.Weight.DemiBold)
+        # Fixed heights on every text row: a long album title must not be
+        # allowed to grow its card and push the rows below it around.
+        title = make_label(
+            self._elide_to_lines(candidate.title, line_height, _TITLE_LINES),
+            size=Metrics.FONT_SM,
+            weight=QFont.Weight.DemiBold,
+        )
         title.setWordWrap(True)
-        title.setFixedWidth(THUMB_SIZE)
+        title.setFixedSize(THUMB_SIZE, line_height * _TITLE_LINES)
+        title.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
         layout.addWidget(title)
 
-        artist = make_label(candidate.artist, size=Metrics.FONT_SM, style=LABEL_SECONDARY())
-        artist.setWordWrap(True)
-        artist.setFixedWidth(THUMB_SIZE)
+        artist = make_label(
+            self._elide(candidate.artist, line_height),
+            size=Metrics.FONT_SM,
+            style=LABEL_SECONDARY(),
+        )
+        artist.setFixedSize(THUMB_SIZE, line_height)
         layout.addWidget(artist)
 
-        detail = make_label(candidate.detail_line, size=Metrics.FONT_SM, style=LABEL_SECONDARY())
-        detail.setFixedWidth(THUMB_SIZE)
+        detail = make_label(
+            self._elide(candidate.detail_line, line_height),
+            size=Metrics.FONT_SM,
+            style=LABEL_SECONDARY(),
+        )
+        detail.setFixedSize(THUMB_SIZE, line_height)
         layout.addWidget(detail)
 
         if load_thumbnail:
             self._load_thumbnail(candidate.thumb_url)
+
+    @staticmethod
+    def _elide(text: str, _line_height: int) -> str:
+        """Shorten text to one card-width line so it cannot wrap."""
+        if not text:
+            return ""
+        metrics = QFontMetrics(QFont(FONT_FAMILY, Metrics.FONT_SM))
+        return metrics.elidedText(text, Qt.TextElideMode.ElideRight, THUMB_SIZE)
+
+    @staticmethod
+    def _elide_to_lines(text: str, line_height: int, lines: int) -> str:
+        """Shorten wrapped text to ``lines`` rows, marking the cut with an ellipsis.
+
+        Qt only elides single lines, and a bare fixed height clips mid-word with
+        no visual sign it was truncated — so a cut title reads as if it were the
+        whole title.
+        """
+        if not text:
+            return ""
+        metrics = QFontMetrics(QFont(FONT_FAMILY, Metrics.FONT_SM))
+        bounds = QRect(0, 0, THUMB_SIZE, 0)
+        flags = Qt.TextFlag.TextWordWrap
+        limit = line_height * lines
+
+        if metrics.boundingRect(bounds, flags, text).height() <= limit:
+            return text
+
+        truncated = text
+        while truncated:
+            truncated = truncated[:-1].rstrip()
+            candidate = f"{truncated}…"
+            if metrics.boundingRect(bounds, flags, candidate).height() <= limit:
+                return candidate
+        return text
 
     def mousePressEvent(self, event) -> None:  # noqa: N802 (Qt naming)
         if event.button() == Qt.MouseButton.LeftButton:

--- a/src/iopenpod/gui/widgets/artworkSearchDialog.py
+++ b/src/iopenpod/gui/widgets/artworkSearchDialog.py
@@ -62,6 +62,13 @@ def _provider_modules():
 class ArtworkSearchDialog(QDialog):
     """Search two keyless providers for album art, or paste an image URL."""
 
+    # Carries the downloaded temp image path once a pick (or pasted URL)
+    # finishes downloading. The dialog stays open when this fires — the
+    # track editor runs the crop dialog on top of it and only closes this
+    # dialog itself once the crop is accepted, so cancelling the cropper
+    # returns to a still-open search dialog with results intact.
+    imageReady = pyqtSignal(str)
+
     def __init__(
         self,
         seed: SeedQuery,
@@ -76,9 +83,17 @@ class ArtworkSearchDialog(QDialog):
         self._chosen_path: str | None = None
         self._candidates: list[ArtworkCandidate] = []
         self._seen_urls: set[str] = set()
+        self._source_counts: dict[str, int] = {}
         self._failed_providers: list[str] = []
+        self._first_failure_info = None
         self._pending_providers = 0
         self._showing_error = False
+        # Set once this dialog itself is rejected or closed (Cancel, Esc, the
+        # window-manager close control). A download already in flight when
+        # that happens still lands afterwards; _on_downloaded checks this to
+        # delete the temp file instead of emitting imageReady into a dialog
+        # nobody is looking at anymore, which would otherwise leak the file.
+        self._abandoned = False
         # Bumped on every _on_search call so late-arriving results/failures
         # from a superseded search (the user re-searched before the old
         # workers finished) can be told apart from the current one and
@@ -228,6 +243,7 @@ class ArtworkSearchDialog(QDialog):
 
         self._clear_results()
         self._failed_providers = []
+        self._first_failure_info = None
         self._showing_error = False
         self._pending_providers = len(modules)
         self._search_generation += 1
@@ -240,16 +256,25 @@ class ArtworkSearchDialog(QDialog):
         provider_names = ", ".join(module.SOURCE_NAME for module in modules)
         self._state_panel.show_loading("Searching for artwork…", f"Checking {provider_names}.")
 
+        # Each provider gets a guaranteed share of the grid so a fast
+        # provider (iTunes, ~300ms) cannot answer with a full page before a
+        # slow one (MusicBrainz, rate-limited to 1req/s plus a second CAA
+        # round trip) ever gets a chance to contribute.
+        per_provider_budget = max(1, MAX_RESULTS // len(modules))
+
         pool = ThreadPoolSingleton.get_instance()
         for module in modules:
             name = module.SOURCE_NAME
-            worker = Worker(module.search, seed)
+            worker = Worker(module.search, seed, per_provider_budget)
             worker.signals.result.connect(
                 lambda candidates, gen=generation: self.append_results(candidates, _generation=gen)
             )
             worker.signals.error.connect(
-                lambda _error, provider=name, gen=generation: self.note_provider_failed(provider, _generation=gen)
+                lambda error_tuple, provider=name, gen=generation: self.note_provider_failed(
+                    provider, error_tuple, _generation=gen
+                )
             )
+            worker.signals.finished.connect(lambda gen=generation: self._on_worker_finished(_generation=gen))
             pool.start(worker)
 
     def append_results(self, candidates: list[ArtworkCandidate], *, _generation: int | None = None) -> None:
@@ -260,20 +285,33 @@ class ArtworkSearchDialog(QDialog):
         superseded by a newer one is dropped rather than mixed into the
         current results. Direct callers (tests, and the picking code below)
         omit it, which always applies unconditionally.
+
+        Each source is capped at its guaranteed share (``MAX_RESULTS //``
+        provider count) so long as another provider is still outstanding;
+        once every other provider has already reported in (success or
+        failure — see ``_on_worker_finished``/``note_provider_failed``),
+        the last one may use whatever grid capacity remains rather than
+        being held to its fixed share.
         """
         if _generation is not None and _generation != self._search_generation:
             log.debug("Dropping stale artwork results from generation %s (current %s)", _generation, self._search_generation)
             return
 
-        self._pending_providers = max(0, self._pending_providers - 1)
+        modules_count = max(1, len(_provider_modules()))
+        base_budget = max(1, MAX_RESULTS // modules_count)
+        effective_budget = MAX_RESULTS if self._pending_providers <= 1 else base_budget
+
         added = False
         for candidate in candidates or []:
             if len(self._candidates) >= MAX_RESULTS:
                 break
             if candidate.full_url in self._seen_urls:
                 continue
+            if self._source_counts.get(candidate.source, 0) >= effective_budget:
+                continue
             self._seen_urls.add(candidate.full_url)
             self._candidates.append(candidate)
+            self._source_counts[candidate.source] = self._source_counts.get(candidate.source, 0) + 1
             self._add_card(candidate, len(self._candidates) - 1)
             added = True
 
@@ -283,30 +321,61 @@ class ArtworkSearchDialog(QDialog):
             self._grid_host.show()
         self._refresh_status()
 
-    def note_provider_failed(self, provider: str, *, _generation: int | None = None) -> None:
+    def note_provider_failed(self, provider: str, error_tuple=None, *, _generation: int | None = None) -> None:
         """Record a provider failure. Only both failing is fatal.
 
         ``_generation`` mirrors ``append_results``: a failure reported by a
         superseded search's worker is dropped instead of being counted
         against the current search's pending-provider total.
+
+        ``error_tuple`` is the ``(exc_type, value, traceback)`` tuple from
+        ``Worker.signals.error``; its ``describe_artwork_error`` info is kept
+        so the both-failed panel can show the real reason (MusicBrainz busy,
+        an HTTP status, etc.) instead of always the same generic copy.
         """
         if _generation is not None and _generation != self._search_generation:
             log.debug("Dropping stale provider failure from generation %s (current %s)", _generation, self._search_generation)
             return
 
-        self._pending_providers = max(0, self._pending_providers - 1)
         if provider not in self._failed_providers:
             self._failed_providers.append(provider)
+
+        if error_tuple is not None and self._first_failure_info is None:
+            from iopenpod.artwork_search.errors import describe_artwork_error
+
+            self._first_failure_info = describe_artwork_error(error_tuple[1])
 
         provider_count = len(_provider_modules())
         if not self._candidates and len(self._failed_providers) >= provider_count:
             self._showing_error = True
             self._grid_host.hide()
             self._state_panel.show()
-            self._state_panel.show_error(
-                "Artwork search did not work",
-                "Neither artwork service answered. Check your connection and try again.",
-            )
+            info = self._first_failure_info
+            if info is not None:
+                self._state_panel.show_error(info.title, info.message, code=info.code)
+            else:
+                self._state_panel.show_error(
+                    "Artwork search did not work",
+                    "Neither artwork service answered. Check your connection and try again.",
+                )
+        self._refresh_status()
+
+    def _on_worker_finished(self, *, _generation: int | None = None) -> None:
+        """Decrement the pending-provider count. Connected to every worker's ``finished``.
+
+        ``Worker.run`` (application/runtime.py) emits exactly one
+        ``finished`` per run in all three outcomes: result, error, or being
+        cancelled with neither (which happens when
+        ``DeviceManager.cancel_all_operations()`` fires mid-search, e.g. on
+        eject or a device disconnect that is not user-driven). Decrementing
+        here — instead of in ``append_results``/``note_provider_failed``,
+        which only run on two of those three outcomes — is what keeps a
+        cancelled search from wedging the dialog on "Searching…" forever.
+        """
+        if _generation is not None and _generation != self._search_generation:
+            log.debug("Dropping stale worker-finished from generation %s (current %s)", _generation, self._search_generation)
+            return
+        self._pending_providers = max(0, self._pending_providers - 1)
         self._refresh_status()
 
     def _refresh_status(self) -> None:
@@ -341,6 +410,7 @@ class ArtworkSearchDialog(QDialog):
     def _clear_results(self) -> None:
         self._candidates = []
         self._seen_urls = set()
+        self._source_counts = {}
         while self._grid.count():
             item = self._grid.takeAt(0)
             widget = item.widget() if item is not None else None
@@ -380,11 +450,25 @@ class ArtworkSearchDialog(QDialog):
         ThreadPoolSingleton.get_instance().start(worker)
 
     def _on_downloaded(self, path: str) -> None:
+        if self._abandoned:
+            # The dialog was closed (window-manager close, Cancel, Esc)
+            # while this download was still in flight. A top-level QDialog
+            # can be closed regardless of setEnabled(False), so this worker
+            # kept running and only now delivered its result to a dialog
+            # nobody is looking at. Nothing downstream will ever claim this
+            # temp file, so delete it here instead of leaking it.
+            self._delete_temp_file(path)
+            return
+
         self.setEnabled(True)
         self._chosen_path = path
-        self.accept()
+        self._status_label.setText("Ready")
+        self.imageReady.emit(path)
 
     def _on_download_error(self, error_tuple, action: str) -> None:
+        if self._abandoned:
+            return
+
         from PyQt6.QtWidgets import QMessageBox
 
         from iopenpod.artwork_search.errors import describe_artwork_error
@@ -394,6 +478,23 @@ class ArtworkSearchDialog(QDialog):
         info = describe_artwork_error(value, action=action)
         self._status_label.setText(info.title)
         QMessageBox.warning(self, info.title, info.message)
+
+    @staticmethod
+    def _delete_temp_file(path: str) -> None:
+        import os
+
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    def reject(self) -> None:
+        self._abandoned = True
+        super().reject()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        self._abandoned = True
+        super().closeEvent(event)
 
 
 class _ArtworkResultCard(QFrame):

--- a/src/iopenpod/gui/widgets/artworkSearchDialog.py
+++ b/src/iopenpod/gui/widgets/artworkSearchDialog.py
@@ -68,15 +68,23 @@ class ArtworkSearchDialog(QDialog):
         parent: QWidget | None = None,
         *,
         auto_search: bool = True,
+        load_thumbnails: bool = True,
     ):
         super().__init__(parent)
         self._seed = seed
+        self._load_thumbnails = load_thumbnails
         self._chosen_path: str | None = None
         self._candidates: list[ArtworkCandidate] = []
         self._seen_urls: set[str] = set()
         self._failed_providers: list[str] = []
         self._pending_providers = 0
         self._showing_error = False
+        # Bumped on every _on_search call so late-arriving results/failures
+        # from a superseded search (the user re-searched before the old
+        # workers finished) can be told apart from the current one and
+        # ignored, instead of corrupting the new search's candidate list
+        # and pending-provider count.
+        self._search_generation = 0
 
         self.setWindowTitle("Find Artwork Online")
         self.setMinimumSize(640, 560)
@@ -222,24 +230,41 @@ class ArtworkSearchDialog(QDialog):
         self._failed_providers = []
         self._showing_error = False
         self._pending_providers = len(modules)
+        self._search_generation += 1
+        generation = self._search_generation
         self._search_btn.setEnabled(False)
+        self._search_input.setEnabled(False)
         self._status_label.setText("Searching…")
         self._grid_host.hide()
         self._state_panel.show()
-        self._state_panel.show_loading("Searching for artwork…", "Checking iTunes and the Cover Art Archive.")
+        provider_names = ", ".join(module.SOURCE_NAME for module in modules)
+        self._state_panel.show_loading("Searching for artwork…", f"Checking {provider_names}.")
 
         pool = ThreadPoolSingleton.get_instance()
         for module in modules:
             name = module.SOURCE_NAME
             worker = Worker(module.search, seed)
-            worker.signals.result.connect(self.append_results)
+            worker.signals.result.connect(
+                lambda candidates, gen=generation: self.append_results(candidates, _generation=gen)
+            )
             worker.signals.error.connect(
-                lambda _error, provider=name: self.note_provider_failed(provider)
+                lambda _error, provider=name, gen=generation: self.note_provider_failed(provider, _generation=gen)
             )
             pool.start(worker)
 
-    def append_results(self, candidates: list[ArtworkCandidate]) -> None:
-        """Add one provider's results to the grid. Safe to call repeatedly."""
+    def append_results(self, candidates: list[ArtworkCandidate], *, _generation: int | None = None) -> None:
+        """Add one provider's results to the grid. Safe to call repeatedly.
+
+        ``_generation`` lets a background worker's callback identify which
+        search it belongs to; a result from a search that has since been
+        superseded by a newer one is dropped rather than mixed into the
+        current results. Direct callers (tests, and the picking code below)
+        omit it, which always applies unconditionally.
+        """
+        if _generation is not None and _generation != self._search_generation:
+            log.debug("Dropping stale artwork results from generation %s (current %s)", _generation, self._search_generation)
+            return
+
         self._pending_providers = max(0, self._pending_providers - 1)
         added = False
         for candidate in candidates or []:
@@ -258,8 +283,17 @@ class ArtworkSearchDialog(QDialog):
             self._grid_host.show()
         self._refresh_status()
 
-    def note_provider_failed(self, provider: str) -> None:
-        """Record a provider failure. Only both failing is fatal."""
+    def note_provider_failed(self, provider: str, *, _generation: int | None = None) -> None:
+        """Record a provider failure. Only both failing is fatal.
+
+        ``_generation`` mirrors ``append_results``: a failure reported by a
+        superseded search's worker is dropped instead of being counted
+        against the current search's pending-provider total.
+        """
+        if _generation is not None and _generation != self._search_generation:
+            log.debug("Dropping stale provider failure from generation %s (current %s)", _generation, self._search_generation)
+            return
+
         self._pending_providers = max(0, self._pending_providers - 1)
         if provider not in self._failed_providers:
             self._failed_providers.append(provider)
@@ -281,6 +315,7 @@ class ArtworkSearchDialog(QDialog):
 
         if self._pending_providers == 0:
             self._search_btn.setEnabled(True)
+            self._search_input.setEnabled(True)
 
         count = len(self._candidates)
         if count:
@@ -313,7 +348,7 @@ class ArtworkSearchDialog(QDialog):
                 widget.deleteLater()
 
     def _add_card(self, candidate: ArtworkCandidate, index: int) -> None:
-        card = _ArtworkResultCard(candidate, self)
+        card = _ArtworkResultCard(candidate, self, load_thumbnail=self._load_thumbnails)
         card.picked.connect(self._on_pick)
         self._grid.addWidget(card, index // GRID_COLUMNS, index % GRID_COLUMNS)
 
@@ -366,7 +401,7 @@ class _ArtworkResultCard(QFrame):
 
     picked = pyqtSignal(str)
 
-    def __init__(self, candidate: ArtworkCandidate, parent: QWidget | None = None):
+    def __init__(self, candidate: ArtworkCandidate, parent: QWidget | None = None, *, load_thumbnail: bool = True):
         super().__init__(parent)
         self._candidate = candidate
         self.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -409,7 +444,8 @@ class _ArtworkResultCard(QFrame):
         detail.setFixedWidth(THUMB_SIZE)
         layout.addWidget(detail)
 
-        self._load_thumbnail(candidate.thumb_url)
+        if load_thumbnail:
+            self._load_thumbnail(candidate.thumb_url)
 
     def mousePressEvent(self, event) -> None:  # noqa: N802 (Qt naming)
         if event.button() == Qt.MouseButton.LeftButton:

--- a/src/iopenpod/gui/widgets/artworkSearchDialog.py
+++ b/src/iopenpod/gui/widgets/artworkSearchDialog.py
@@ -124,6 +124,9 @@ class ArtworkSearchDialog(QDialog):
         self._candidates: list[ArtworkCandidate] = []
         self._seen_urls: set[str] = set()
         self._source_counts: dict[str, int] = {}
+        # Results held back by a source's share cap while another provider
+        # was still outstanding, replayed into the grid once none are.
+        self._deferred: list[ArtworkCandidate] = []
         # Cards are kept so a resize can re-place them at a new column count
         # without destroying already-loaded thumbnails. Column count is
         # recomputed from the viewport width on show and on every resize.
@@ -311,12 +314,16 @@ class ArtworkSearchDialog(QDialog):
         # provider (iTunes, ~300ms) cannot answer with a full page before a
         # slow one (MusicBrainz, rate-limited to 1req/s plus a second CAA
         # round trip) ever gets a chance to contribute.
-        per_provider_budget = max(1, MAX_RESULTS // len(modules))
-
+        # Ask each provider for a full grid, not its guaranteed share. The
+        # share is an *acceptance* cap applied while another provider is
+        # still outstanding; anything over it is held in _deferred and used
+        # to fill the grid once every provider has reported. Fetching only
+        # the share would leave nothing to fill it with when the other
+        # provider returns nothing — which for Cover Art Archive is common.
         pool = ThreadPoolSingleton.get_instance()
         for module in modules:
             name = module.SOURCE_NAME
-            worker = Worker(module.search, seed, per_provider_budget)
+            worker = Worker(module.search, seed, MAX_RESULTS)
             worker.signals.result.connect(
                 lambda candidates, gen=generation: self.append_results(candidates, _generation=gen)
             )
@@ -359,11 +366,12 @@ class ArtworkSearchDialog(QDialog):
             if candidate.full_url in self._seen_urls:
                 continue
             if self._source_counts.get(candidate.source, 0) >= effective_budget:
+                # Over this source's share while another provider may still
+                # need the slots. Hold it rather than discard it: if that
+                # provider returns nothing, _fill_from_deferred puts it back.
+                self._deferred.append(candidate)
                 continue
-            self._seen_urls.add(candidate.full_url)
-            self._candidates.append(candidate)
-            self._source_counts[candidate.source] = self._source_counts.get(candidate.source, 0) + 1
-            self._add_card(candidate, len(self._candidates) - 1)
+            self._accept_candidate(candidate)
             added = True
 
         if added:
@@ -371,6 +379,37 @@ class ArtworkSearchDialog(QDialog):
             self._state_panel.hide()
             self._grid_host.show()
         self._refresh_status()
+
+    def _accept_candidate(self, candidate: ArtworkCandidate) -> None:
+        """Take a candidate into the grid and record it against its source."""
+        self._seen_urls.add(candidate.full_url)
+        self._candidates.append(candidate)
+        self._source_counts[candidate.source] = self._source_counts.get(candidate.source, 0) + 1
+        self._add_card(candidate, len(self._candidates) - 1)
+
+    def _fill_from_deferred(self) -> None:
+        """Use held-back results to fill the grid once every provider is done.
+
+        The per-source cap reserves slots for a provider that may still be
+        working. Once none are outstanding there is nobody left to reserve
+        for, so a provider that returned more than its share may use the
+        space a provider that returned little or nothing did not need.
+        """
+        if not self._deferred:
+            return
+
+        added = False
+        while self._deferred and len(self._candidates) < MAX_RESULTS:
+            candidate = self._deferred.pop(0)
+            if candidate.full_url in self._seen_urls:
+                continue
+            self._accept_candidate(candidate)
+            added = True
+
+        if added:
+            self._showing_error = False
+            self._state_panel.hide()
+            self._grid_host.show()
 
     def note_provider_failed(self, provider: str, error_tuple=None, *, _generation: int | None = None) -> None:
         """Record a provider failure. Only both failing is fatal.
@@ -427,6 +466,8 @@ class ArtworkSearchDialog(QDialog):
             log.debug("Dropping stale worker-finished from generation %s (current %s)", _generation, self._search_generation)
             return
         self._pending_providers = max(0, self._pending_providers - 1)
+        if self._pending_providers == 0:
+            self._fill_from_deferred()
         self._refresh_status()
 
     def _refresh_status(self) -> None:
@@ -462,6 +503,7 @@ class ArtworkSearchDialog(QDialog):
         self._candidates = []
         self._seen_urls = set()
         self._source_counts = {}
+        self._deferred = []
         self._cards = []
         while self._grid.count():
             item = self._grid.takeAt(0)

--- a/src/iopenpod/gui/widgets/artworkSearchDialog.py
+++ b/src/iopenpod/gui/widgets/artworkSearchDialog.py
@@ -1,0 +1,443 @@
+"""Online artwork search dialog — iTunes and Cover Art Archive.
+
+Searches run on background workers to keep the UI responsive.  The dialog's
+only output is a local temp image path, which the track editor feeds into the
+same crop dialog the file picker uses.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFont, QImage, QPixmap
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from iopenpod.artwork_search.models import ArtworkCandidate
+from iopenpod.artwork_search.query import SeedQuery
+
+from ..hidpi import scale_pixmap_for_display
+from ..styles import (
+    FONT_FAMILY,
+    LABEL_SECONDARY,
+    Metrics,
+    accent_btn_css,
+    btn_css,
+    input_css,
+    make_label,
+    make_scroll_area,
+    paint_css,
+)
+from .podcastStates import PodcastStatePanel
+
+log = logging.getLogger(__name__)
+
+MAX_RESULTS = 24
+GRID_COLUMNS = 3
+THUMB_SIZE = 140
+
+
+def _provider_modules():
+    """The artwork provider modules, each declaring its own SOURCE_NAME.
+
+    Imported lazily (matching the local-import style used elsewhere in this
+    dialog and in podcastSearchDialog.py) so importing this module never
+    pulls in the network-facing provider modules at load time.
+    """
+    from iopenpod.artwork_search import coverart, itunes
+
+    return (itunes, coverart)
+
+
+class ArtworkSearchDialog(QDialog):
+    """Search two keyless providers for album art, or paste an image URL."""
+
+    def __init__(
+        self,
+        seed: SeedQuery,
+        parent: QWidget | None = None,
+        *,
+        auto_search: bool = True,
+    ):
+        super().__init__(parent)
+        self._seed = seed
+        self._chosen_path: str | None = None
+        self._candidates: list[ArtworkCandidate] = []
+        self._seen_urls: set[str] = set()
+        self._failed_providers: list[str] = []
+        self._pending_providers = 0
+        self._showing_error = False
+
+        self.setWindowTitle("Find Artwork Online")
+        self.setMinimumSize(640, 560)
+        self.resize(720, 640)
+        self.setStyleSheet(f"""
+            QDialog {{
+                background: {paint_css('modal.background')};
+            }}
+        """)
+
+        self._build_ui()
+        if auto_search and seed.text.strip():
+            self._on_search()
+
+    # ── Public surface used by the track editor and by tests ─────────────
+
+    def chosen_image_path(self) -> str | None:
+        """Temp PNG path for the picked image; only valid once accepted."""
+        return self._chosen_path
+
+    def search_text(self) -> str:
+        return self._search_input.text()
+
+    def result_count(self) -> int:
+        return len(self._candidates)
+
+    def status_text(self) -> str:
+        return self._status_label.text()
+
+    def is_showing_error(self) -> bool:
+        return self._showing_error
+
+    # ── UI construction ──────────────────────────────────────────────────
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        search_row = QHBoxLayout()
+        search_row.setSpacing(8)
+
+        self._search_input = QLineEdit()
+        self._search_input.setText(self._seed.text)
+        self._search_input.setPlaceholderText("Search for an album…")
+        self._search_input.setFont(QFont(FONT_FAMILY, Metrics.FONT_MD))
+        self._search_input.setStyleSheet(input_css(padding="8px 12px"))
+        self._search_input.returnPressed.connect(self._on_search)
+        search_row.addWidget(self._search_input, stretch=1)
+
+        self._search_btn = QPushButton("Search")
+        self._search_btn.setFont(QFont(FONT_FAMILY, Metrics.FONT_MD))
+        self._search_btn.setStyleSheet(accent_btn_css())
+        self._search_btn.setFixedHeight(36)
+        self._search_btn.clicked.connect(self._on_search)
+        search_row.addWidget(self._search_btn)
+
+        layout.addLayout(search_row)
+
+        self._status_label = make_label(
+            "Search for album artwork",
+            size=Metrics.FONT_SM,
+            style=LABEL_SECONDARY(),
+        )
+        layout.addWidget(self._status_label)
+
+        self._results_container = QWidget()
+        self._outer_layout = QVBoxLayout(self._results_container)
+        self._outer_layout.setContentsMargins(0, 0, 0, 0)
+        self._outer_layout.setSpacing(8)
+
+        self._state_panel = PodcastStatePanel(compact=True)
+        self._state_panel.show_empty(
+            "Find album artwork",
+            "Search by artist and album, or paste an image address below.",
+            glyph="album",
+        )
+        self._state_panel.action_clicked.connect(self._on_search)
+        self._outer_layout.addWidget(self._state_panel)
+
+        self._grid_host = QWidget()
+        self._grid = QGridLayout(self._grid_host)
+        self._grid.setContentsMargins(0, 0, 0, 0)
+        self._grid.setSpacing(10)
+        self._outer_layout.addWidget(self._grid_host)
+        self._outer_layout.addStretch()
+
+        scroll = make_scroll_area(extra_css=f"""
+            QScrollArea {{
+                border: 1px solid {paint_css('border.subtle')};
+                border-radius: {Metrics.BORDER_RADIUS_SM}px;
+            }}
+        """)
+        scroll.setWidget(self._results_container)
+        layout.addWidget(scroll, stretch=1)
+
+        url_row = QHBoxLayout()
+        url_row.setSpacing(8)
+        url_row.addWidget(
+            make_label("Or paste image URL:", size=Metrics.FONT_SM, style=LABEL_SECONDARY())
+        )
+
+        self._url_input = QLineEdit()
+        self._url_input.setPlaceholderText("https://example.com/cover.jpg")
+        self._url_input.setFont(QFont(FONT_FAMILY, Metrics.FONT_SM))
+        self._url_input.setStyleSheet(input_css(padding="6px 10px"))
+        self._url_input.returnPressed.connect(self._on_use_url)
+        url_row.addWidget(self._url_input, stretch=1)
+
+        self._url_btn = QPushButton("Use URL")
+        self._url_btn.setFont(QFont(FONT_FAMILY, Metrics.FONT_SM))
+        self._url_btn.setStyleSheet(accent_btn_css())
+        self._url_btn.setFixedHeight(32)
+        self._url_btn.clicked.connect(self._on_use_url)
+        url_row.addWidget(self._url_btn)
+
+        layout.addLayout(url_row)
+
+        close_btn = QPushButton("Cancel")
+        close_btn.setFont(QFont(FONT_FAMILY, Metrics.FONT_MD))
+        close_btn.setStyleSheet(btn_css())
+        close_btn.setFixedHeight(36)
+        close_btn.clicked.connect(self.reject)
+        layout.addWidget(close_btn, alignment=Qt.AlignmentFlag.AlignRight)
+
+    # ── Search ───────────────────────────────────────────────────────────
+
+    def _on_search(self) -> None:
+        query = self._search_input.text().strip()
+        if not query:
+            return
+
+        from iopenpod.application.runtime import ThreadPoolSingleton, Worker
+
+        modules = _provider_modules()
+
+        seed = SeedQuery(text=query, artist=self._seed.artist, album=self._seed.album)
+        if query != self._seed.text:
+            # The user retyped the box, so the separated parts no longer apply.
+            seed = SeedQuery(text=query)
+
+        self._clear_results()
+        self._failed_providers = []
+        self._showing_error = False
+        self._pending_providers = len(modules)
+        self._search_btn.setEnabled(False)
+        self._status_label.setText("Searching…")
+        self._grid_host.hide()
+        self._state_panel.show()
+        self._state_panel.show_loading("Searching for artwork…", "Checking iTunes and the Cover Art Archive.")
+
+        pool = ThreadPoolSingleton.get_instance()
+        for module in modules:
+            name = module.SOURCE_NAME
+            worker = Worker(module.search, seed)
+            worker.signals.result.connect(self.append_results)
+            worker.signals.error.connect(
+                lambda _error, provider=name: self.note_provider_failed(provider)
+            )
+            pool.start(worker)
+
+    def append_results(self, candidates: list[ArtworkCandidate]) -> None:
+        """Add one provider's results to the grid. Safe to call repeatedly."""
+        self._pending_providers = max(0, self._pending_providers - 1)
+        added = False
+        for candidate in candidates or []:
+            if len(self._candidates) >= MAX_RESULTS:
+                break
+            if candidate.full_url in self._seen_urls:
+                continue
+            self._seen_urls.add(candidate.full_url)
+            self._candidates.append(candidate)
+            self._add_card(candidate, len(self._candidates) - 1)
+            added = True
+
+        if added:
+            self._showing_error = False
+            self._state_panel.hide()
+            self._grid_host.show()
+        self._refresh_status()
+
+    def note_provider_failed(self, provider: str) -> None:
+        """Record a provider failure. Only both failing is fatal."""
+        self._pending_providers = max(0, self._pending_providers - 1)
+        if provider not in self._failed_providers:
+            self._failed_providers.append(provider)
+
+        provider_count = len(_provider_modules())
+        if not self._candidates and len(self._failed_providers) >= provider_count:
+            self._showing_error = True
+            self._grid_host.hide()
+            self._state_panel.show()
+            self._state_panel.show_error(
+                "Artwork search did not work",
+                "Neither artwork service answered. Check your connection and try again.",
+            )
+        self._refresh_status()
+
+    def _refresh_status(self) -> None:
+        if self._pending_providers > 0 and not self._candidates:
+            return
+
+        if self._pending_providers == 0:
+            self._search_btn.setEnabled(True)
+
+        count = len(self._candidates)
+        if count:
+            text = f"Found {count} cover{'s' if count != 1 else ''}"
+        elif self._showing_error:
+            text = "Artwork search did not work"
+        elif self._pending_providers == 0:
+            text = "No artwork found"
+            self._grid_host.hide()
+            self._state_panel.show()
+            self._state_panel.show_empty(
+                "No artwork found",
+                "Try a different album name, or paste an image address below.",
+                glyph="album",
+            )
+        else:
+            text = "Searching…"
+
+        if self._failed_providers:
+            text += f"  ·  {', '.join(self._failed_providers)} did not respond"
+        self._status_label.setText(text)
+
+    def _clear_results(self) -> None:
+        self._candidates = []
+        self._seen_urls = set()
+        while self._grid.count():
+            item = self._grid.takeAt(0)
+            widget = item.widget() if item is not None else None
+            if widget is not None:
+                widget.deleteLater()
+
+    def _add_card(self, candidate: ArtworkCandidate, index: int) -> None:
+        card = _ArtworkResultCard(candidate, self)
+        card.picked.connect(self._on_pick)
+        self._grid.addWidget(card, index // GRID_COLUMNS, index % GRID_COLUMNS)
+
+    # ── Picking ──────────────────────────────────────────────────────────
+
+    def _on_pick(self, url: str) -> None:
+        self._download_and_accept(url, action="download artwork")
+
+    def _on_use_url(self) -> None:
+        url = self._url_input.text().strip()
+        if url:
+            self._download_and_accept(url, action="download that image")
+
+    def _download_and_accept(self, url: str, *, action: str) -> None:
+        from iopenpod.application.runtime import ThreadPoolSingleton, Worker
+        from iopenpod.artwork_search.download import fetch_image, save_temp_image
+
+        def _job() -> str:
+            return save_temp_image(fetch_image(url))
+
+        self.setEnabled(False)
+        self._status_label.setText("Downloading…")
+
+        worker = Worker(_job)
+        worker.signals.result.connect(self._on_downloaded)
+        worker.signals.error.connect(
+            lambda error_tuple, act=action: self._on_download_error(error_tuple, act)
+        )
+        ThreadPoolSingleton.get_instance().start(worker)
+
+    def _on_downloaded(self, path: str) -> None:
+        self.setEnabled(True)
+        self._chosen_path = path
+        self.accept()
+
+    def _on_download_error(self, error_tuple, action: str) -> None:
+        from PyQt6.QtWidgets import QMessageBox
+
+        from iopenpod.artwork_search.errors import describe_artwork_error
+
+        self.setEnabled(True)
+        _type, value, _tb = error_tuple
+        info = describe_artwork_error(value, action=action)
+        self._status_label.setText(info.title)
+        QMessageBox.warning(self, info.title, info.message)
+
+
+class _ArtworkResultCard(QFrame):
+    """One clickable cover result with an async thumbnail."""
+
+    picked = pyqtSignal(str)
+
+    def __init__(self, candidate: ArtworkCandidate, parent: QWidget | None = None):
+        super().__init__(parent)
+        self._candidate = candidate
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setStyleSheet(f"""
+            _ArtworkResultCard {{
+                background: {paint_css('surface.inset')};
+                border: 1px solid {paint_css('border.subtle')};
+                border-radius: {Metrics.BORDER_RADIUS_SM}px;
+            }}
+            _ArtworkResultCard:hover {{
+                background: {paint_css('surface.hover')};
+            }}
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(4)
+
+        self._art_label = QLabel()
+        self._art_label.setFixedSize(THUMB_SIZE, THUMB_SIZE)
+        self._art_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._art_label.setStyleSheet(f"""
+            background: {paint_css('surface.raised')};
+            border-radius: {Metrics.BORDER_RADIUS_SM}px;
+            color: {paint_css('text.tertiary')};
+        """)
+        layout.addWidget(self._art_label, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        title = make_label(candidate.title, size=Metrics.FONT_SM, weight=QFont.Weight.DemiBold)
+        title.setWordWrap(True)
+        title.setFixedWidth(THUMB_SIZE)
+        layout.addWidget(title)
+
+        artist = make_label(candidate.artist, size=Metrics.FONT_SM, style=LABEL_SECONDARY())
+        artist.setWordWrap(True)
+        artist.setFixedWidth(THUMB_SIZE)
+        layout.addWidget(artist)
+
+        detail = make_label(candidate.detail_line, size=Metrics.FONT_SM, style=LABEL_SECONDARY())
+        detail.setFixedWidth(THUMB_SIZE)
+        layout.addWidget(detail)
+
+        self._load_thumbnail(candidate.thumb_url)
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.picked.emit(self._candidate.full_url)
+        super().mousePressEvent(event)
+
+    def _load_thumbnail(self, url: str) -> None:
+        if not url:
+            return
+
+        from iopenpod.application.runtime import ThreadPoolSingleton, Worker
+        from iopenpod.artwork_search.download import fetch_image
+
+        worker = Worker(fetch_image, url)
+        worker.signals.result.connect(self._on_thumbnail)
+        ThreadPoolSingleton.get_instance().start(worker)
+
+    def _on_thumbnail(self, data: bytes) -> None:
+        image = QImage()
+        if not image.loadFromData(data):
+            return
+        self._art_label.setPixmap(
+            scale_pixmap_for_display(
+                QPixmap.fromImage(image),
+                THUMB_SIZE,
+                THUMB_SIZE,
+                widget=self._art_label,
+                aspect_mode=Qt.AspectRatioMode.KeepAspectRatio,
+                transform_mode=Qt.TransformationMode.SmoothTransformation,
+            )
+        )

--- a/src/iopenpod/gui/widgets/trackEditorDialog.py
+++ b/src/iopenpod/gui/widgets/trackEditorDialog.py
@@ -2023,6 +2023,7 @@ class _ArtworkPreviewPanel(QFrame):
 
     changeArtworkRequested = pyqtSignal()
     unifyArtworkRequested = pyqtSignal()
+    searchArtworkRequested = pyqtSignal()
 
     def __init__(
         self,
@@ -2093,6 +2094,13 @@ class _ArtworkPreviewPanel(QFrame):
         self._unify_btn.setToolTip("Pick one selected artwork image for all selected tracks")
         self._unify_btn.clicked.connect(self.unifyArtworkRequested.emit)
         header.addWidget(self._unify_btn)
+
+        self._search_btn = QPushButton("Find Artwork Online")
+        self._search_btn.setStyleSheet(btn_css())
+        self._search_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._search_btn.setToolTip("Search iTunes and the Cover Art Archive for a cover")
+        self._search_btn.clicked.connect(self.searchArtworkRequested.emit)
+        header.addWidget(self._search_btn)
 
         layout.addLayout(header)
 
@@ -2775,6 +2783,7 @@ class TrackEditorDialog(QDialog):
             self._artwork_panel = _ArtworkPreviewPanel(artworks, self._tracks, body)
             self._artwork_panel.changeArtworkRequested.connect(self._choose_artwork)
             self._artwork_panel.unifyArtworkRequested.connect(self._unify_artwork)
+            self._artwork_panel.searchArtworkRequested.connect(self._search_artwork)
             body_layout.addWidget(self._artwork_panel)
 
         page_rows: list[_TrackFieldRow] = []
@@ -2963,6 +2972,51 @@ class TrackEditorDialog(QDialog):
         if self._artwork_panel is not None:
             self._artwork_panel.set_pending_artwork(cropped, file_path)
         self._update_change_summary()
+
+    def _search_artwork(self) -> None:
+        from iopenpod.artwork_search.query import seed_query_from_tracks
+
+        from .artworkSearchDialog import ArtworkSearchDialog
+
+        search_dialog = ArtworkSearchDialog(seed_query_from_tracks(self._tracks), self)
+        if search_dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+
+        downloaded_path = search_dialog.chosen_image_path()
+        if not downloaded_path:
+            return
+
+        try:
+            crop_dialog = _ArtworkCropDialog(downloaded_path, self)
+        except (OSError, UnidentifiedImageError) as exc:
+            QMessageBox.warning(self, "Artwork Image", f"Could not open that image:\n\n{exc}")
+            self._remove_temp_file(downloaded_path)
+            return
+
+        accepted = crop_dialog.exec() == QDialog.DialogCode.Accepted
+        cropped = crop_dialog.cropped_image() if accepted else None
+        self._remove_temp_file(downloaded_path)
+        if cropped is None:
+            return
+
+        try:
+            temp_path = self._save_cropped_artwork(cropped)
+        except Exception as exc:
+            QMessageBox.warning(self, "Artwork Image", f"Could not prepare cropped artwork:\n\n{exc}")
+            return
+
+        self._discard_pending_artwork()
+        self._pending_artwork_path = temp_path
+        if self._artwork_panel is not None:
+            self._artwork_panel.set_pending_artwork(cropped, downloaded_path)
+        self._update_change_summary()
+
+    @staticmethod
+    def _remove_temp_file(path: str) -> None:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
 
     def _unify_artwork(self) -> None:
         if self._artwork_panel is None:

--- a/src/iopenpod/gui/widgets/trackEditorDialog.py
+++ b/src/iopenpod/gui/widgets/trackEditorDialog.py
@@ -2979,17 +2979,26 @@ class TrackEditorDialog(QDialog):
         from .artworkSearchDialog import ArtworkSearchDialog
 
         search_dialog = ArtworkSearchDialog(seed_query_from_tracks(self._tracks), self)
-        if search_dialog.exec() != QDialog.DialogCode.Accepted:
-            return
+        search_dialog.imageReady.connect(
+            lambda downloaded_path, dlg=search_dialog: self._on_artwork_search_image_ready(dlg, downloaded_path)
+        )
+        # The dialog closes itself (accept()) once a crop is applied
+        # below; a plain Cancel/Esc/window-close just rejects it here with
+        # nothing left to do.
+        search_dialog.exec()
 
-        downloaded_path = search_dialog.chosen_image_path()
-        if not downloaded_path:
-            return
+    def _on_artwork_search_image_ready(self, search_dialog: QDialog, downloaded_path: str) -> None:
+        """Run the crop dialog on a just-downloaded image, on top of the still-open search dialog.
 
+        Cancelling the cropper (or failing to open the download) must return
+        to the search dialog with its results intact rather than discarding
+        the search, so this only closes ``search_dialog`` on a successful
+        crop. Every path removes the downloaded temp file exactly once.
+        """
         try:
-            crop_dialog = _ArtworkCropDialog(downloaded_path, self)
+            crop_dialog = _ArtworkCropDialog(downloaded_path, search_dialog)
         except (OSError, UnidentifiedImageError) as exc:
-            QMessageBox.warning(self, "Artwork Image", f"Could not open that image:\n\n{exc}")
+            QMessageBox.warning(search_dialog, "Artwork Image", f"Could not open that image:\n\n{exc}")
             self._remove_temp_file(downloaded_path)
             return
 
@@ -3002,7 +3011,7 @@ class TrackEditorDialog(QDialog):
         try:
             temp_path = self._save_cropped_artwork(cropped)
         except Exception as exc:
-            QMessageBox.warning(self, "Artwork Image", f"Could not prepare cropped artwork:\n\n{exc}")
+            QMessageBox.warning(search_dialog, "Artwork Image", f"Could not prepare cropped artwork:\n\n{exc}")
             return
 
         self._discard_pending_artwork()
@@ -3010,6 +3019,7 @@ class TrackEditorDialog(QDialog):
         if self._artwork_panel is not None:
             self._artwork_panel.set_pending_artwork(cropped, downloaded_path)
         self._update_change_summary()
+        search_dialog.accept()
 
     @staticmethod
     def _remove_temp_file(path: str) -> None:

--- a/tests/test_artwork_download.py
+++ b/tests/test_artwork_download.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from iopenpod.artwork_search import download
+from iopenpod.artwork_search.errors import ArtworkSearchError
+
+
+def _png_bytes(size: int = 32) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (size, size), (10, 20, 30)).save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, content_type: str = "image/png", status: int = 200):
+        self.headers = {"Content-Type": content_type}
+        self.status_code = status
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise AssertionError("should not be reached in these tests")
+
+    def iter_content(self, chunk_size: int = 8192):
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start : start + chunk_size]
+
+    def close(self) -> None:
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self._response = response
+        self.max_redirects = None
+        self.closed = False
+
+    def get(self, url, timeout=None, stream=None, headers=None):
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+    def close(self):
+        self.closed = True
+
+
+def test_rejects_non_http_scheme() -> None:
+    with pytest.raises(ArtworkSearchError):
+        download.fetch_image("file:///etc/passwd")
+
+
+def test_rejects_empty_url() -> None:
+    with pytest.raises(ArtworkSearchError):
+        download.fetch_image("   ")
+
+
+def test_fetches_a_valid_image(monkeypatch) -> None:
+    payload = _png_bytes()
+    monkeypatch.setattr(download.requests, "Session", lambda: _FakeSession(_FakeResponse(payload)))
+    assert download.fetch_image("https://example.com/a.png") == payload
+
+
+def test_rejects_non_image_content_type(monkeypatch) -> None:
+    monkeypatch.setattr(
+        download.requests,
+        "Session",
+        lambda: _FakeSession(_FakeResponse(b"<html></html>", content_type="text/html")),
+    )
+    with pytest.raises(ArtworkSearchError) as excinfo:
+        download.fetch_image("https://example.com/a.html")
+    assert "image" in excinfo.value.info.message.lower()
+
+
+def test_rejects_body_over_size_cap(monkeypatch) -> None:
+    oversized = b"\x89PNG" + b"0" * (download.MAX_IMAGE_BYTES + 1)
+    monkeypatch.setattr(download.requests, "Session", lambda: _FakeSession(_FakeResponse(oversized)))
+    with pytest.raises(ArtworkSearchError) as excinfo:
+        download.fetch_image("https://example.com/big.png")
+    assert "too large" in excinfo.value.info.message.lower()
+
+
+def test_rejects_body_that_is_not_a_real_image(monkeypatch) -> None:
+    monkeypatch.setattr(
+        download.requests,
+        "Session",
+        lambda: _FakeSession(_FakeResponse(b"not an image at all")),
+    )
+    with pytest.raises(ArtworkSearchError):
+        download.fetch_image("https://example.com/fake.png")
+
+
+def test_user_agent_has_name_version_and_contact_url() -> None:
+    agent = download.user_agent()
+    assert agent.startswith("iOpenPod/")
+    assert "github.com/TheRealSavi/iOpenPod" in agent
+
+
+def test_save_temp_image_writes_recognisable_temp_file(tmp_path) -> None:
+    import os
+
+    path = download.save_temp_image(_png_bytes())
+    try:
+        assert os.path.basename(path).startswith("iopenpod-artwork-")
+        with Image.open(path) as image:
+            assert image.size == (32, 32)
+    finally:
+        os.remove(path)
+
+
+def test_session_redirect_cap_is_five(monkeypatch) -> None:
+    session = _FakeSession(_FakeResponse(_png_bytes()))
+    monkeypatch.setattr(download.requests, "Session", lambda: session)
+    download.fetch_image("https://example.com/a.png")
+    assert session.max_redirects == download.MAX_REDIRECTS
+    assert download.MAX_REDIRECTS == 5

--- a/tests/test_artwork_download.py
+++ b/tests/test_artwork_download.py
@@ -86,7 +86,7 @@ def test_rejects_body_over_size_cap(monkeypatch) -> None:
     monkeypatch.setattr(download.requests, "Session", lambda: _FakeSession(_FakeResponse(oversized)))
     with pytest.raises(ArtworkSearchError) as excinfo:
         download.fetch_image("https://example.com/big.png")
-    assert "too large" in excinfo.value.info.message.lower()
+    assert "too large" in excinfo.value.info.title.lower()
 
 
 def test_rejects_body_that_is_not_a_real_image(monkeypatch) -> None:

--- a/tests/test_artwork_download.py
+++ b/tests/test_artwork_download.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 
 import pytest
+import requests
 from PIL import Image
 
 from iopenpod.artwork_search import download
@@ -23,7 +24,9 @@ class _FakeResponse:
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
-            raise AssertionError("should not be reached in these tests")
+            error = requests.HTTPError(f"HTTP {self.status_code}")
+            error.response = self  # type: ignore[attr-defined]
+            raise error
 
     def iter_content(self, chunk_size: int = 8192):
         for start in range(0, len(self._body), chunk_size):
@@ -123,3 +126,45 @@ def test_session_redirect_cap_is_five(monkeypatch) -> None:
     download.fetch_image("https://example.com/a.png")
     assert session.max_redirects == download.MAX_REDIRECTS
     assert download.MAX_REDIRECTS == 5
+
+
+def test_http_client_error_becomes_an_artwork_search_error(monkeypatch) -> None:
+    """A 404 must not escape as a raw requests.HTTPError.
+
+    fetch_image promises ArtworkSearchError on every rejection; a caller
+    catching only that would otherwise see an unhandled requests exception.
+    """
+    session = _FakeSession(_FakeResponse(b"<html>not found</html>", content_type="text/html", status=404))
+    monkeypatch.setattr(download.requests, "Session", lambda: session)
+
+    with pytest.raises(ArtworkSearchError) as excinfo:
+        download.fetch_image("https://example.com/missing.png")
+
+    assert excinfo.value.info.code == "HTTP 404"
+    assert session.closed is True
+
+
+def test_http_server_error_becomes_an_artwork_search_error(monkeypatch) -> None:
+    session = _FakeSession(_FakeResponse(b"", content_type="text/html", status=503))
+    monkeypatch.setattr(download.requests, "Session", lambda: session)
+
+    with pytest.raises(ArtworkSearchError) as excinfo:
+        download.fetch_image("https://example.com/down.png")
+
+    assert excinfo.value.info.code == "HTTP 503"
+
+
+def test_connection_failure_becomes_an_artwork_search_error(monkeypatch) -> None:
+    session = _FakeSession(requests.ConnectionError("name resolution failed"))
+    monkeypatch.setattr(download.requests, "Session", lambda: session)
+
+    with pytest.raises(ArtworkSearchError):
+        download.fetch_image("https://nope.invalid/cover.png")
+
+
+def test_timeout_becomes_an_artwork_search_error(monkeypatch) -> None:
+    session = _FakeSession(requests.Timeout("too slow"))
+    monkeypatch.setattr(download.requests, "Session", lambda: session)
+
+    with pytest.raises(ArtworkSearchError):
+        download.fetch_image("https://example.com/slow.png")

--- a/tests/test_artwork_search_coverart.py
+++ b/tests/test_artwork_search_coverart.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+import requests
+
+from iopenpod.artwork_search import coverart
+from iopenpod.artwork_search.errors import ArtworkSearchError
+from iopenpod.artwork_search.query import SeedQuery
+
+_MBID = "48117b90-a16e-34ca-a514-19c702df1158"
+
+_MB_PAYLOAD = {
+    "count": 1,
+    "release-groups": [
+        {
+            "id": _MBID,
+            "title": "Discovery",
+            "score": 100,
+            "primary-type": "Album",
+            "first-release-date": "2001-02-26",
+            "artist-credit": [{"name": "Daft Punk"}],
+        }
+    ],
+}
+
+_CAA_PAYLOAD = {
+    "images": [
+        {
+            "front": False,
+            "image": "https://coverartarchive.org/release/x/1.jpg",
+            "thumbnails": {"250": "https://caa/1-250.jpg", "1200": "https://caa/1-1200.jpg"},
+        },
+        {
+            "front": True,
+            "image": "https://coverartarchive.org/release/x/2.png",
+            "thumbnails": {
+                "250": "https://caa/2-250.jpg",
+                "500": "https://caa/2-500.jpg",
+                "1200": "https://caa/2-1200.jpg",
+            },
+        },
+    ]
+}
+
+
+class _FakeResponse:
+    def __init__(self, payload, status: int = 200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            error = requests.HTTPError(f"HTTP {self.status_code}")
+            error.response = self  # type: ignore[attr-defined]
+            raise error
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit_sleep(monkeypatch):
+    """Keep the 1 req/sec guard from making the suite slow."""
+    monkeypatch.setattr(coverart.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(coverart, "_last_mb_request", 0.0, raising=False)
+
+
+def _router(mb=_MB_PAYLOAD, caa=_CAA_PAYLOAD, caa_status: int = 200):
+    def fake_get(url, params=None, timeout=None, headers=None):
+        if "musicbrainz.org" in url:
+            return _FakeResponse(mb)
+        return _FakeResponse(caa, status=caa_status)
+
+    return fake_get
+
+
+def test_empty_query_makes_no_request(monkeypatch) -> None:
+    def explode(*args, **kwargs):
+        raise AssertionError("no request should be made")
+
+    monkeypatch.setattr(coverart.requests, "get", explode)
+    assert coverart.search(SeedQuery(text="  ")) == []
+
+
+def test_search_returns_front_cover_only(monkeypatch) -> None:
+    monkeypatch.setattr(coverart.requests, "get", _router())
+    results = coverart.search(SeedQuery(text="daft punk discovery"))
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.title == "Discovery"
+    assert candidate.artist == "Daft Punk"
+    assert candidate.year == "2001"
+    assert candidate.source == "Cover Art Archive"
+    assert candidate.thumb_url == "https://caa/2-250.jpg"
+    assert candidate.full_url == "https://caa/2-1200.jpg"
+
+
+def test_full_url_falls_back_through_thumbnail_sizes(monkeypatch) -> None:
+    caa = {
+        "images": [
+            {
+                "front": True,
+                "image": "https://caa/orig.png",
+                "thumbnails": {"500": "https://caa/x-500.jpg"},
+            }
+        ]
+    }
+    monkeypatch.setattr(coverart.requests, "get", _router(caa=caa))
+    candidate = coverart.search(SeedQuery(text="x"))[0]
+    assert candidate.full_url == "https://caa/x-500.jpg"
+    assert candidate.thumb_url == "https://caa/x-500.jpg"
+
+
+def test_full_url_falls_back_to_original_image(monkeypatch) -> None:
+    caa = {"images": [{"front": True, "image": "https://caa/orig.png", "thumbnails": {}}]}
+    monkeypatch.setattr(coverart.requests, "get", _router(caa=caa))
+    candidate = coverart.search(SeedQuery(text="x"))[0]
+    assert candidate.full_url == "https://caa/orig.png"
+
+
+def test_caa_404_is_a_skip_not_an_error(monkeypatch) -> None:
+    monkeypatch.setattr(coverart.requests, "get", _router(caa={}, caa_status=404))
+    assert coverart.search(SeedQuery(text="x")) == []
+
+
+def test_release_group_with_no_front_image_is_skipped(monkeypatch) -> None:
+    caa = {"images": [{"front": False, "image": "https://caa/back.jpg", "thumbnails": {}}]}
+    monkeypatch.setattr(coverart.requests, "get", _router(caa=caa))
+    assert coverart.search(SeedQuery(text="x")) == []
+
+
+def test_musicbrainz_busy_body_raises_friendly_error(monkeypatch) -> None:
+    busy = {"error": "The MusicBrainz web server is currently busy. Please try again later."}
+    monkeypatch.setattr(coverart.requests, "get", _router(mb=busy))
+    with pytest.raises(ArtworkSearchError) as excinfo:
+        coverart.search(SeedQuery(text="x"))
+    assert "busy" in excinfo.value.info.message.lower()
+
+
+def test_network_error_raises_friendly_error(monkeypatch) -> None:
+    def fail(*args, **kwargs):
+        raise requests.ConnectionError("offline")
+
+    monkeypatch.setattr(coverart.requests, "get", fail)
+    with pytest.raises(ArtworkSearchError):
+        coverart.search(SeedQuery(text="x"))
+
+
+def test_musicbrainz_request_uses_fielded_query_and_user_agent(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        if "musicbrainz.org" in url:
+            captured["params"] = params
+            captured["headers"] = headers
+            return _FakeResponse(_MB_PAYLOAD)
+        return _FakeResponse(_CAA_PAYLOAD)
+
+    monkeypatch.setattr(coverart.requests, "get", fake_get)
+    coverart.search(SeedQuery(text="x", artist="Daft Punk", album="Discovery"))
+    assert captured["params"]["query"] == 'releasegroup:"Discovery" AND artist:"Daft Punk"'
+    assert captured["params"]["fmt"] == "json"
+    assert captured["headers"]["User-Agent"].startswith("iOpenPod/")

--- a/tests/test_artwork_search_coverart.py
+++ b/tests/test_artwork_search_coverart.py
@@ -148,6 +148,65 @@ def test_network_error_raises_friendly_error(monkeypatch) -> None:
         coverart.search(SeedQuery(text="x"))
 
 
+_MBID_A = "48117b90-a16e-34ca-a514-19c702df1158"
+_MBID_B = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+_MB_PAYLOAD_TWO = {
+    "count": 2,
+    "release-groups": [
+        {
+            "id": _MBID_A,
+            "title": "Bad Payload",
+            "score": 100,
+            "first-release-date": "2001-02-26",
+            "artist-credit": [{"name": "Daft Punk"}],
+        },
+        {
+            "id": _MBID_B,
+            "title": "Discovery",
+            "score": 90,
+            "first-release-date": "2001-02-26",
+            "artist-credit": [{"name": "Daft Punk"}],
+        },
+    ],
+}
+
+
+def _router_by_mbid(mb, caa_by_mbid: dict, status_by_mbid: dict | None = None):
+    status_by_mbid = status_by_mbid or {}
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        if "musicbrainz.org" in url:
+            return _FakeResponse(mb)
+        mbid = url.rsplit("/", 1)[-1]
+        return _FakeResponse(caa_by_mbid[mbid], status=status_by_mbid.get(mbid, 200))
+
+    return fake_get
+
+
+def test_one_release_groups_404_does_not_affect_the_other(monkeypatch) -> None:
+    caa_by_mbid = {_MBID_A: {}, _MBID_B: _CAA_PAYLOAD}
+    monkeypatch.setattr(
+        coverart.requests,
+        "get",
+        _router_by_mbid(_MB_PAYLOAD_TWO, caa_by_mbid, status_by_mbid={_MBID_A: 404}),
+    )
+    results = coverart.search(SeedQuery(text="daft punk discovery"))
+    assert len(results) == 1
+    assert results[0].title == "Discovery"
+
+
+def test_one_release_groups_malformed_payload_does_not_affect_the_other(monkeypatch) -> None:
+    """A malformed CAA payload for one release group (e.g. a non-dict images entry)
+    must be skipped like any other failure, not crash the whole batch and wipe out
+    an already-successful sibling lookup."""
+    caa_by_mbid = {_MBID_A: {"images": [42]}, _MBID_B: _CAA_PAYLOAD}
+    monkeypatch.setattr(coverart.requests, "get", _router_by_mbid(_MB_PAYLOAD_TWO, caa_by_mbid))
+    results = coverart.search(SeedQuery(text="daft punk discovery"))
+    assert len(results) == 1
+    assert results[0].title == "Discovery"
+
+
 def test_musicbrainz_request_uses_fielded_query_and_user_agent(monkeypatch) -> None:
     captured: dict = {}
 

--- a/tests/test_artwork_search_dialog.py
+++ b/tests/test_artwork_search_dialog.py
@@ -194,3 +194,67 @@ def test_download_abandoned_by_closing_the_dialog_deletes_the_temp_file(dialog, 
 
     assert not leaked.exists()
     assert dialog.chosen_image_path() is None
+
+
+def _cards(dialog) -> list:
+    """Every result card currently laid out in the grid, in grid order."""
+    grid = dialog._grid
+    return [
+        grid.itemAt(index).widget()
+        for index in range(grid.count())
+        if grid.itemAt(index).widget() is not None
+    ]
+
+
+def test_every_card_is_the_same_fixed_size(dialog) -> None:
+    """Cards must not resize to fill the row, whatever their text length."""
+    from iopenpod.gui.widgets.artworkSearchDialog import CARD_WIDTH
+
+    dialog.append_results([
+        _candidate("https://a/1.jpg"),
+        ArtworkCandidate(
+            title="A Very Long Album Title That Would Otherwise Wrap Onto Several Lines",
+            artist="An Extremely Long Artist Name That Would Also Wrap",
+            source="iTunes",
+            thumb_url="https://a/2.jpg",
+            full_url="https://a/2.jpg",
+            year="1999",
+            width=1200,
+        ),
+    ])
+    dialog._grid.activate()
+
+    sizes = {(card.width(), card.height()) for card in _cards(dialog)}
+    assert len(sizes) == 1, f"cards differ in size: {sizes}"
+    assert sizes.pop()[0] == CARD_WIDTH
+
+
+def test_a_lone_result_does_not_stretch_to_the_full_width(dialog) -> None:
+    """One result used to expand across the whole viewport."""
+    from iopenpod.gui.widgets.artworkSearchDialog import CARD_WIDTH
+
+    dialog.resize(900, 700)
+    dialog.append_results([_candidate("https://a/1.jpg")])
+    dialog._grid.activate()
+
+    assert _cards(dialog)[0].width() == CARD_WIDTH
+
+
+def test_late_results_do_not_move_the_cards_already_on_screen(dialog) -> None:
+    """The misclick bug: a slow provider landing must not shift existing cards.
+
+    Cover Art Archive answers well after iTunes, so a user reaching for an
+    iTunes result must not have it move out from under the cursor.
+    """
+    dialog.resize(900, 700)
+    dialog.append_results([_candidate(f"https://a/{i}.jpg") for i in range(2)])
+    dialog._grid.activate()
+    before = [(card.pos(), card.size()) for card in _cards(dialog)]
+
+    dialog.append_results([
+        _candidate(f"https://b/{i}.jpg", source="Cover Art Archive") for i in range(6)
+    ])
+    dialog._grid.activate()
+    after = [(card.pos(), card.size()) for card in _cards(dialog)][: len(before)]
+
+    assert after == before

--- a/tests/test_artwork_search_dialog.py
+++ b/tests/test_artwork_search_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from PyQt6.QtWidgets import QApplication
 
 from iopenpod.artwork_search.models import ArtworkCandidate
 from iopenpod.artwork_search.query import SeedQuery
@@ -206,10 +207,23 @@ def _cards(dialog) -> list:
     ]
 
 
+def _shown(dialog, width: int, height: int = 700):
+    """Show the dialog at a real size so the viewport has a usable width.
+
+    Column count is derived from the viewport, so a dialog that was never
+    shown reports a meaningless single column.
+    """
+    dialog.resize(width, height)
+    dialog.show()
+    dialog._grid.activate()
+    return dialog
+
+
 def test_every_card_is_the_same_fixed_size(dialog) -> None:
     """Cards must not resize to fill the row, whatever their text length."""
     from iopenpod.gui.widgets.artworkSearchDialog import CARD_WIDTH
 
+    _shown(dialog, 900)
     dialog.append_results([
         _candidate("https://a/1.jpg"),
         ArtworkCandidate(
@@ -233,7 +247,7 @@ def test_a_lone_result_does_not_stretch_to_the_full_width(dialog) -> None:
     """One result used to expand across the whole viewport."""
     from iopenpod.gui.widgets.artworkSearchDialog import CARD_WIDTH
 
-    dialog.resize(900, 700)
+    _shown(dialog, 900)
     dialog.append_results([_candidate("https://a/1.jpg")])
     dialog._grid.activate()
 
@@ -246,7 +260,7 @@ def test_late_results_do_not_move_the_cards_already_on_screen(dialog) -> None:
     Cover Art Archive answers well after iTunes, so a user reaching for an
     iTunes result must not have it move out from under the cursor.
     """
-    dialog.resize(900, 700)
+    _shown(dialog, 900)
     dialog.append_results([_candidate(f"https://a/{i}.jpg") for i in range(2)])
     dialog._grid.activate()
     before = [(card.pos(), card.size()) for card in _cards(dialog)]
@@ -258,3 +272,47 @@ def test_late_results_do_not_move_the_cards_already_on_screen(dialog) -> None:
     after = [(card.pos(), card.size()) for card in _cards(dialog)][: len(before)]
 
     assert after == before
+
+
+def test_column_count_follows_the_window_width(dialog) -> None:
+    """Wider window, more cards per row — not a hardcoded three."""
+    from iopenpod.gui.widgets.artworkSearchDialog import columns_for_width
+
+    _shown(dialog, 640)
+    dialog.append_results([_candidate(f"https://a/{i}.jpg") for i in range(12)])
+
+    seen = {}
+    for width in (640, 900, 1200, 900, 640):
+        dialog.resize(width, 700)
+        dialog._grid.activate()
+        seen[width] = dialog.grid_columns()
+
+    assert seen[900] > seen[640], f"widening did not add a column: {seen}"
+    assert seen[1200] > seen[900], f"widening did not add a column: {seen}"
+    # Shrinking must give the columns back, not leave them stuck wide.
+    assert seen[640] == columns_for_width(dialog._viewport_width())
+
+
+def test_widening_then_narrowing_does_not_overlap_rows(dialog) -> None:
+    """Going back to a narrower window must give the extra row real space.
+
+    The grid caches its size hint. Widening drops a row and shrinks the
+    host; narrowing again needs that row back, and without invalidating the
+    hint the host stays short and the fixed-height cards are stacked on top
+    of one another — cards overlapping by ~70px in the real dialog.
+    """
+    _shown(dialog, 720)
+    dialog.append_results([_candidate(f"https://a/{i}.jpg") for i in range(12)])
+
+    for width in (720, 1100, 720, 900, 640):
+        dialog.resize(width, 640)
+        QApplication.processEvents()
+        dialog._grid.activate()
+        QApplication.processEvents()
+        cards = _cards(dialog)
+        card_height = max(card.height() for card in cards)
+        rows = sorted({card.y() for card in cards})
+        pitches = [b - a for a, b in zip(rows, rows[1:], strict=False)]
+        assert all(pitch >= card_height for pitch in pitches), (
+            f"rows overlap at width {width}: pitches={pitches} card_height={card_height}"
+        )

--- a/tests/test_artwork_search_dialog.py
+++ b/tests/test_artwork_search_dialog.py
@@ -316,3 +316,58 @@ def test_widening_then_narrowing_does_not_overlap_rows(dialog) -> None:
         assert all(pitch >= card_height for pitch in pitches), (
             f"rows overlap at width {width}: pitches={pitches} card_height={card_height}"
         )
+
+
+def test_grid_fills_up_when_the_other_provider_returns_nothing(dialog) -> None:
+    """A half-empty grid was the cost of the anti-starvation cap.
+
+    iTunes is held to its share while Cover Art Archive is outstanding, but
+    CAA often has no art for a query. Once every provider has settled there
+    is nobody left to reserve slots for, so the results held back by the cap
+    must fill the grid rather than leaving the user with half of it.
+    """
+    from iopenpod.gui.widgets.artworkSearchDialog import MAX_RESULTS
+
+    dialog._pending_providers = 2
+    dialog.append_results([_candidate(f"https://itunes/{i}.jpg") for i in range(MAX_RESULTS)])
+    assert dialog.result_count() == MAX_RESULTS // 2, "iTunes should be held to its share here"
+
+    dialog._on_worker_finished()          # iTunes settles
+    dialog.append_results([])             # Cover Art Archive has nothing
+    dialog._on_worker_finished()          # CAA settles, nothing left to reserve for
+
+    assert dialog.result_count() == MAX_RESULTS
+
+
+def test_grid_fills_up_when_the_other_provider_never_reports(dialog) -> None:
+    """Same reclaim must happen when a provider is cancelled mid-search."""
+    from iopenpod.gui.widgets.artworkSearchDialog import MAX_RESULTS
+
+    dialog._pending_providers = 2
+    dialog.append_results([_candidate(f"https://itunes/{i}.jpg") for i in range(MAX_RESULTS)])
+
+    dialog._on_worker_finished()
+    dialog._on_worker_finished()          # cancelled worker: finished only, no results
+
+    assert dialog.result_count() == MAX_RESULTS
+
+
+def test_both_providers_delivering_still_splits_the_grid(dialog) -> None:
+    """Reclaim must not let the fast provider take slots the slow one used."""
+    from iopenpod.gui.widgets.artworkSearchDialog import MAX_RESULTS
+
+    dialog._pending_providers = 2
+    dialog.append_results([_candidate(f"https://itunes/{i}.jpg") for i in range(MAX_RESULTS)])
+    dialog._on_worker_finished()
+    dialog.append_results(
+        [_candidate(f"https://caa/{i}.jpg", source="Cover Art Archive") for i in range(MAX_RESULTS)]
+    )
+    dialog._on_worker_finished()
+
+    by_source: dict[str, int] = {}
+    for candidate in dialog._candidates:
+        by_source[candidate.source] = by_source.get(candidate.source, 0) + 1
+
+    assert dialog.result_count() == MAX_RESULTS
+    assert by_source["iTunes"] == MAX_RESULTS // 2
+    assert by_source["Cover Art Archive"] == MAX_RESULTS // 2

--- a/tests/test_artwork_search_dialog.py
+++ b/tests/test_artwork_search_dialog.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from iopenpod.artwork_search.models import ArtworkCandidate
+from iopenpod.artwork_search.query import SeedQuery
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+
+@pytest.fixture
+def dialog(qtbot):
+    from iopenpod.gui.widgets.artworkSearchDialog import ArtworkSearchDialog
+
+    widget = ArtworkSearchDialog(
+        SeedQuery(text="Daft Punk Discovery", artist="Daft Punk", album="Discovery"),
+        auto_search=False,
+    )
+    qtbot.addWidget(widget)
+    return widget
+
+
+def _candidate(url: str, source: str = "iTunes") -> ArtworkCandidate:
+    return ArtworkCandidate(
+        title="Discovery",
+        artist="Daft Punk",
+        source=source,
+        thumb_url=url,
+        full_url=url,
+        year="2001",
+        width=1200,
+    )
+
+
+def test_search_box_is_pre_seeded(dialog) -> None:
+    assert dialog.search_text() == "Daft Punk Discovery"
+
+
+def test_no_image_chosen_before_acceptance(dialog) -> None:
+    assert dialog.chosen_image_path() is None
+
+
+def test_results_render_cards(dialog) -> None:
+    dialog.append_results([_candidate("https://a/1.jpg"), _candidate("https://a/2.jpg")])
+    assert dialog.result_count() == 2
+
+
+def test_duplicate_full_urls_are_suppressed(dialog) -> None:
+    dialog.append_results([_candidate("https://a/1.jpg")])
+    dialog.append_results([_candidate("https://a/1.jpg", source="Cover Art Archive")])
+    assert dialog.result_count() == 1
+
+
+def test_different_urls_from_both_providers_both_kept(dialog) -> None:
+    dialog.append_results([_candidate("https://a/1.jpg")])
+    dialog.append_results([_candidate("https://b/1.jpg", source="Cover Art Archive")])
+    assert dialog.result_count() == 2
+
+
+def test_results_are_capped(dialog) -> None:
+    from iopenpod.gui.widgets.artworkSearchDialog import MAX_RESULTS
+
+    dialog.append_results([_candidate(f"https://a/{index}.jpg") for index in range(MAX_RESULTS + 10)])
+    assert dialog.result_count() == MAX_RESULTS
+
+
+def test_one_provider_failing_keeps_the_other_results(dialog) -> None:
+    dialog.append_results([_candidate("https://a/1.jpg")])
+    dialog.note_provider_failed("Cover Art Archive")
+    assert dialog.result_count() == 1
+    assert "Cover Art Archive" in dialog.status_text()
+
+
+def test_both_providers_failing_shows_error_state(dialog) -> None:
+    dialog.note_provider_failed("iTunes")
+    dialog.note_provider_failed("Cover Art Archive")
+    assert dialog.result_count() == 0
+    assert dialog.is_showing_error()

--- a/tests/test_artwork_search_dialog.py
+++ b/tests/test_artwork_search_dialog.py
@@ -105,3 +105,92 @@ def test_stale_generation_failure_does_not_decrement_pending_providers(dialog) -
     assert dialog._pending_providers == 2
     assert dialog._failed_providers == []
     assert not dialog.is_showing_error()
+
+
+def test_fast_provider_cannot_starve_slow_provider(dialog) -> None:
+    """A full-budget iTunes batch must still leave room for CAA results.
+
+    Regression test for the whole-branch finding where an unbounded iTunes
+    worker could return a full page of MAX_RESULTS candidates before Cover
+    Art Archive ever landed, so the per-source cap in ``append_results``
+    zeroed out every later CAA result via the old global-only cap.
+    """
+    from iopenpod.gui.widgets.artworkSearchDialog import MAX_RESULTS
+
+    dialog._pending_providers = 2  # both providers still outstanding
+    dialog.append_results([_candidate(f"https://itunes/{index}.jpg") for index in range(MAX_RESULTS)])
+    dialog.append_results(
+        [_candidate(f"https://caa/{index}.jpg", source="Cover Art Archive") for index in range(6)]
+    )
+
+    sources = {candidate.source for candidate in dialog._candidates}
+    assert "Cover Art Archive" in sources
+    itunes_count = sum(1 for candidate in dialog._candidates if candidate.source == "iTunes")
+    caa_count = sum(1 for candidate in dialog._candidates if candidate.source == "Cover Art Archive")
+    assert itunes_count == MAX_RESULTS // 2
+    assert caa_count == 6
+
+
+def test_last_remaining_provider_may_use_the_remainder(dialog) -> None:
+    """Once the other provider is done, the last one isn't capped to its fixed share."""
+    from iopenpod.gui.widgets.artworkSearchDialog import MAX_RESULTS
+
+    dialog._pending_providers = 2
+    dialog.append_results([_candidate("https://itunes/1.jpg")])  # only 1 of its share used
+    dialog._on_worker_finished()  # iTunes's worker settles; only CAA is left outstanding
+
+    dialog.append_results(
+        [_candidate(f"https://caa/{index}.jpg", source="Cover Art Archive") for index in range(MAX_RESULTS)]
+    )
+    caa_count = sum(1 for candidate in dialog._candidates if candidate.source == "Cover Art Archive")
+    assert caa_count == MAX_RESULTS - 1
+
+
+def test_a_worker_that_only_emits_finished_still_settles_the_dialog(dialog) -> None:
+    """A cancelled Worker (DeviceManager.cancel_all_operations mid-search) emits only ``finished``.
+
+    Regression test: with neither result nor error connected to decrement
+    ``_pending_providers``, the dialog used to stay stuck on "Searching…"
+    forever whenever a device disconnect cancelled one of the two workers.
+    """
+    dialog._pending_providers = 2
+    dialog._search_btn.setEnabled(False)
+    dialog._search_input.setEnabled(False)
+
+    dialog.append_results([_candidate("https://a/1.jpg")])  # iTunes lands normally
+    dialog._on_worker_finished()  # iTunes's own `finished`
+    assert not dialog._search_btn.isEnabled()  # still waiting on the cancelled provider
+
+    dialog._on_worker_finished()  # the cancelled Cover Art Archive worker: only `finished` fires
+
+    assert dialog._search_btn.isEnabled()
+    assert dialog._search_input.isEnabled()
+    assert dialog.result_count() == 1
+
+
+def test_both_providers_failing_surfaces_the_real_error(dialog) -> None:
+    """The both-failed panel must show the actual provider error, not always the generic copy."""
+    from iopenpod.artwork_search.errors import ArtworkErrorInfo, ArtworkSearchError
+
+    busy = ArtworkSearchError(ArtworkErrorInfo(title="MusicBrainz is busy", message="Try again in a moment.", code="MB-BUSY"))
+    dialog.note_provider_failed("Cover Art Archive", (ArtworkSearchError, busy, ""))
+    dialog.note_provider_failed("iTunes", (RuntimeError, RuntimeError("boom"), ""))
+
+    assert dialog.is_showing_error()
+    # The first provider to fail (Cover Art Archive here) sets the reason
+    # shown in the both-failed panel, not the old hardcoded generic copy.
+    assert dialog._first_failure_info is busy.info
+
+
+def test_download_abandoned_by_closing_the_dialog_deletes_the_temp_file(dialog, tmp_path) -> None:
+    """Closing the dialog mid-download must not leak the downloaded temp file."""
+    leaked = tmp_path / "leaked.png"
+    leaked.write_bytes(b"fake-png")
+
+    dialog.reject()  # simulates Cancel/Esc/window-close while a download is in flight
+    assert dialog._abandoned is True
+
+    dialog._on_downloaded(str(leaked))
+
+    assert not leaked.exists()
+    assert dialog.chosen_image_path() is None

--- a/tests/test_artwork_search_dialog.py
+++ b/tests/test_artwork_search_dialog.py
@@ -15,6 +15,7 @@ def dialog(qtbot):
     widget = ArtworkSearchDialog(
         SeedQuery(text="Daft Punk Discovery", artist="Daft Punk", album="Discovery"),
         auto_search=False,
+        load_thumbnails=False,
     )
     qtbot.addWidget(widget)
     return widget
@@ -76,3 +77,31 @@ def test_both_providers_failing_shows_error_state(dialog) -> None:
     dialog.note_provider_failed("Cover Art Archive")
     assert dialog.result_count() == 0
     assert dialog.is_showing_error()
+
+
+def test_stale_generation_results_are_ignored(dialog) -> None:
+    # Simulate a search in flight (generation 1) that is then superseded by
+    # a new search (generation 2) before the old workers report back.
+    dialog._search_generation = 1
+    stale_generation = dialog._search_generation
+    dialog._search_generation += 1
+    dialog._pending_providers = 2
+
+    dialog.append_results([_candidate("https://old/1.jpg")], _generation=stale_generation)
+    assert dialog.result_count() == 0
+    assert dialog._pending_providers == 2  # the new search's counter must be untouched
+
+    dialog.append_results([_candidate("https://new/1.jpg")], _generation=dialog._search_generation)
+    assert dialog.result_count() == 1
+
+
+def test_stale_generation_failure_does_not_decrement_pending_providers(dialog) -> None:
+    dialog._search_generation = 1
+    stale_generation = dialog._search_generation
+    dialog._search_generation += 1
+    dialog._pending_providers = 2
+
+    dialog.note_provider_failed("iTunes", _generation=stale_generation)
+    assert dialog._pending_providers == 2
+    assert dialog._failed_providers == []
+    assert not dialog.is_showing_error()

--- a/tests/test_artwork_search_errors.py
+++ b/tests/test_artwork_search_errors.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+import requests
+
+from iopenpod.artwork_search.errors import (
+    ArtworkErrorInfo,
+    ArtworkSearchError,
+    describe_artwork_error,
+)
+from iopenpod.artwork_search.models import ArtworkCandidate
+
+
+def test_candidate_defaults() -> None:
+    candidate = ArtworkCandidate(
+        title="Discovery",
+        artist="Daft Punk",
+        source="iTunes",
+        thumb_url="https://example.com/t.jpg",
+        full_url="https://example.com/f.jpg",
+    )
+    assert candidate.year == ""
+    assert candidate.width == 0
+
+
+def test_candidate_is_frozen() -> None:
+    candidate = ArtworkCandidate(
+        title="Discovery",
+        artist="Daft Punk",
+        source="iTunes",
+        thumb_url="https://example.com/t.jpg",
+        full_url="https://example.com/f.jpg",
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        candidate.title = "Homework"  # type: ignore[misc]
+
+
+def test_describe_timeout() -> None:
+    info = describe_artwork_error(requests.Timeout("slow"))
+    assert "timed out" in info.title.lower()
+    assert info.message
+
+
+def test_describe_connection_error() -> None:
+    info = describe_artwork_error(requests.ConnectionError("offline"))
+    assert "connection" in info.title.lower()
+
+
+def test_describe_http_error_includes_status_code() -> None:
+    response = requests.Response()
+    response.status_code = 503
+    error = requests.HTTPError("server error", response=response)
+    info = describe_artwork_error(error)
+    assert info.code == "HTTP 503"
+
+
+def test_describe_passes_through_artwork_search_error() -> None:
+    original = ArtworkErrorInfo(title="Custom", message="Custom message", code="X")
+    info = describe_artwork_error(ArtworkSearchError(original))
+    assert info is original
+
+
+def test_describe_unknown_error_mentions_action() -> None:
+    info = describe_artwork_error(ValueError("boom"), action="download artwork")
+    assert "download artwork" in info.message

--- a/tests/test_artwork_search_itunes.py
+++ b/tests/test_artwork_search_itunes.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+import requests
+
+from iopenpod.artwork_search import itunes
+from iopenpod.artwork_search.errors import ArtworkSearchError
+from iopenpod.artwork_search.query import SeedQuery
+
+_ART_100 = "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/fd/dj.qrikkdwj.jpg/100x100bb.jpg"
+
+_PAYLOAD = {
+    "resultCount": 2,
+    "results": [
+        {
+            "collectionName": "Discovery",
+            "artistName": "Daft Punk",
+            "releaseDate": "2001-03-12T08:00:00Z",
+            "artworkUrl100": _ART_100,
+        },
+        {
+            "collectionName": "No Art",
+            "artistName": "Nobody",
+            "releaseDate": "",
+            "artworkUrl100": "",
+        },
+    ],
+}
+
+
+class _FakeResponse:
+    def __init__(self, payload, status: int = 200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def test_artwork_url_at_size_replaces_final_segment() -> None:
+    assert itunes.artwork_url_at_size(_ART_100, 1200).endswith("/1200x1200bb.jpg")
+    assert itunes.artwork_url_at_size(_ART_100, 250).endswith("/250x250bb.jpg")
+
+
+def test_artwork_url_at_size_leaves_unexpected_shape_alone() -> None:
+    other = "https://example.com/cover.jpg"
+    assert itunes.artwork_url_at_size(other, 1200) == other
+
+
+def test_empty_query_makes_no_request(monkeypatch) -> None:
+    def explode(*args, **kwargs):
+        raise AssertionError("no request should be made")
+
+    monkeypatch.setattr(itunes.requests, "get", explode)
+    assert itunes.search(SeedQuery(text="   ")) == []
+
+
+def test_search_parses_results_and_skips_entries_without_artwork(monkeypatch) -> None:
+    monkeypatch.setattr(itunes.requests, "get", lambda *a, **k: _FakeResponse(_PAYLOAD))
+    results = itunes.search(SeedQuery(text="daft punk discovery"))
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.title == "Discovery"
+    assert candidate.artist == "Daft Punk"
+    assert candidate.year == "2001"
+    assert candidate.source == "iTunes"
+    assert candidate.width == 1200
+    assert candidate.thumb_url.endswith("/250x250bb.jpg")
+    assert candidate.full_url.endswith("/1200x1200bb.jpg")
+
+
+def test_search_sends_expected_params(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResponse(_PAYLOAD)
+
+    monkeypatch.setattr(itunes.requests, "get", fake_get)
+    itunes.search(SeedQuery(text="x"), limit=7)
+    assert captured["params"]["entity"] == "album"
+    assert captured["params"]["media"] == "music"
+    assert captured["params"]["limit"] == 7
+
+
+def test_network_error_raises_friendly_error(monkeypatch) -> None:
+    def fail(*args, **kwargs):
+        raise requests.ConnectionError("offline")
+
+    monkeypatch.setattr(itunes.requests, "get", fail)
+    with pytest.raises(ArtworkSearchError):
+        itunes.search(SeedQuery(text="x"))
+
+
+def test_bad_json_raises_friendly_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        itunes.requests,
+        "get",
+        lambda *a, **k: _FakeResponse(ValueError("not json")),
+    )
+    with pytest.raises(ArtworkSearchError):
+        itunes.search(SeedQuery(text="x"))

--- a/tests/test_artwork_search_query.py
+++ b/tests/test_artwork_search_query.py
@@ -42,6 +42,25 @@ def test_seed_single_track_without_album_uses_artist_and_title() -> None:
     assert seed.album == ""
 
 
+def test_seed_single_track_with_album_but_no_artist_searches_album() -> None:
+    tracks = [_track(Album="Discovery", Title="One More Time")]
+    seed = seed_query_from_tracks(tracks)
+    assert seed.text == "Discovery"
+    assert seed.album == "Discovery"
+    assert seed.artist == ""
+
+
+def test_seed_shared_album_with_disagreeing_artists_searches_album() -> None:
+    tracks = [
+        _track(Album="Various Artists Compilation", Artist="Daft Punk", Title="One More Time"),
+        _track(Album="Various Artists Compilation", Artist="Aphex Twin", Title="Xtal"),
+    ]
+    seed = seed_query_from_tracks(tracks)
+    assert seed.text == "Various Artists Compilation"
+    assert seed.album == "Various Artists Compilation"
+    assert seed.artist == ""
+
+
 def test_seed_mixed_selection_is_empty() -> None:
     tracks = [
         _track(Album="Discovery", **{"Album Artist": "Daft Punk"}),

--- a/tests/test_artwork_search_query.py
+++ b/tests/test_artwork_search_query.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from iopenpod.artwork_search.query import (
+    SeedQuery,
+    escape_lucene,
+    lucene_release_group_query,
+    seed_query_from_tracks,
+)
+
+
+def _track(**kwargs: str) -> dict:
+    base = {"Title": "", "Artist": "", "Album": "", "Album Artist": ""}
+    base.update(kwargs)
+    return base
+
+
+def test_seed_uses_shared_album_artist_and_album() -> None:
+    tracks = [
+        _track(Album="Discovery", **{"Album Artist": "Daft Punk"}, Title="One More Time"),
+        _track(Album="Discovery", **{"Album Artist": "Daft Punk"}, Title="Aerodynamic"),
+    ]
+    seed = seed_query_from_tracks(tracks)
+    assert seed.artist == "Daft Punk"
+    assert seed.album == "Discovery"
+    assert seed.text == "Daft Punk Discovery"
+
+
+def test_seed_falls_back_to_artist_when_album_artist_missing() -> None:
+    tracks = [
+        _track(Album="Discovery", Artist="Daft Punk", Title="One More Time"),
+        _track(Album="Discovery", Artist="Daft Punk", Title="Aerodynamic"),
+    ]
+    seed = seed_query_from_tracks(tracks)
+    assert seed.artist == "Daft Punk"
+    assert seed.album == "Discovery"
+
+
+def test_seed_single_track_without_album_uses_artist_and_title() -> None:
+    tracks = [_track(Artist="Aphex Twin", Title="Xtal")]
+    seed = seed_query_from_tracks(tracks)
+    assert seed.text == "Aphex Twin Xtal"
+    assert seed.album == ""
+
+
+def test_seed_mixed_selection_is_empty() -> None:
+    tracks = [
+        _track(Album="Discovery", **{"Album Artist": "Daft Punk"}),
+        _track(Album="Homework", **{"Album Artist": "Daft Punk"}),
+    ]
+    seed = seed_query_from_tracks(tracks)
+    assert seed.text == ""
+    assert seed.album == ""
+
+
+def test_seed_empty_selection_is_empty() -> None:
+    assert seed_query_from_tracks([]).text == ""
+
+
+def test_escape_lucene_escapes_quotes_and_backslashes() -> None:
+    assert escape_lucene('say "hi"') == 'say \\"hi\\"'
+    assert escape_lucene("back\\slash") == "back\\\\slash"
+
+
+def test_fielded_query_when_artist_and_album_known() -> None:
+    seed = SeedQuery(text="Daft Punk Discovery", artist="Daft Punk", album="Discovery")
+    assert lucene_release_group_query(seed) == 'releasegroup:"Discovery" AND artist:"Daft Punk"'
+
+
+def test_free_text_query_when_not_separable() -> None:
+    seed = SeedQuery(text="daft punk discovery", artist="", album="")
+    assert lucene_release_group_query(seed) == "daft punk discovery"
+
+
+def test_fielded_query_escapes_quotes() -> None:
+    seed = SeedQuery(text='x', artist='AC "DC"', album="Back")
+    assert lucene_release_group_query(seed) == 'releasegroup:"Back" AND artist:"AC \\"DC\\""'

--- a/tests/test_track_editor_artwork_search.py
+++ b/tests/test_track_editor_artwork_search.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+
+def _track(**kwargs: str) -> dict:
+    base = {"Title": "One More Time", "Artist": "Daft Punk", "Album": "Discovery", "Album Artist": "Daft Punk"}
+    base.update(kwargs)
+    return base
+
+
+def test_artwork_panel_exposes_a_search_signal() -> None:
+    from iopenpod.gui.widgets.trackEditorDialog import _ArtworkPreviewPanel
+
+    assert hasattr(_ArtworkPreviewPanel, "searchArtworkRequested")
+
+
+def test_panel_has_a_find_artwork_online_button(qtbot) -> None:
+    from iopenpod.gui.widgets.trackEditorDialog import _ArtworkPreviewPanel
+
+    panel = _ArtworkPreviewPanel([], [_track()])
+    qtbot.addWidget(panel)
+    labels = {button.text() for button in panel.findChildren(type(panel._change_btn))}
+    assert "Find Artwork Online" in labels
+
+
+def test_search_button_emits_the_signal(qtbot) -> None:
+    from iopenpod.gui.widgets.trackEditorDialog import _ArtworkPreviewPanel
+
+    panel = _ArtworkPreviewPanel([], [_track()])
+    qtbot.addWidget(panel)
+    with qtbot.waitSignal(panel.searchArtworkRequested, timeout=1000):
+        panel._search_btn.click()
+
+
+def test_editor_seeds_the_search_from_the_selection() -> None:
+    from iopenpod.artwork_search.query import seed_query_from_tracks
+
+    seed = seed_query_from_tracks([_track(), _track(Title="Aerodynamic")])
+    assert seed.artist == "Daft Punk"
+    assert seed.album == "Discovery"


### PR DESCRIPTION
## What this adds

A **Find Artwork Online** button in the track editor's artwork panel. It searches two keyless providers for album art, or takes a pasted image URL, and hands the result to the crop-and-apply pipeline that already exists behind **Change Artwork**.

Today the only way to set artwork is a file picker, so you need the cover already saved on disk.

<img width="720" alt="Find Artwork Online dialog" src="https://github.com/user-attachments/assets/placeholder" />

## Why these providers

Both are keyless and need no account:

- **iTunes Search API** — best hit rate for commercial music, and this repo already uses it for podcast discovery (`podcasts/itunes_search.py`).
- **MusicBrainz + Cover Art Archive** — fills the gaps for obscure, live and non-commercial releases.

Discogs was deliberately left out: it serves images only to authenticated requests, and its terms forbid shipping a shared token in an open-source binary, so every user would have to register and paste a personal token. The provider list is a plain tuple of modules, so adding it later is one module plus one entry.

## How it fits in

`TrackEditorDialog._choose_artwork` already does file picker → `_ArtworkCropDialog` → temp PNG → `_pending_artwork_path`. The new `_search_artwork` does the same with the search dialog in place of the file picker, so preview, pending state, temp cleanup and the sync write are all inherited unchanged.

`iopenpod/artwork_search/` is a new top-level package with no Qt dependency, which keeps the providers unit-testable and sits outside the GUI-forbidden import prefixes in `check_architecture.py` — **`architecture_rules.json` is untouched**.

## API behaviour worth knowing

Verified against the live services, and each has a test:

- **MusicBrainz reports overload in the response body, not the status line** (`{"error": "...currently busy..."}` under a non-failing status). Hit on the very first call while developing.
- **Cover Art Archive answers 404 with an HTML body when a release has no art.** That's the normal "no cover" answer, not an error.
- **Fielded Lucene queries matter a lot.** Free text for `daft punk discovery` ranked a novelty remix first (score 100) with the real album third (69); `releasegroup:"Discovery" AND artist:"Daft Punk"` puts the right album first at 100. The editor already has Artist and Album separately, so the query is built fielded.
- iTunes artwork URLs rewrite `100x100bb.jpg` → `1200x1200bb.jpg`, matching `_ARTWORK_CROP_OUTPUT_SIZE`. The service clamps to source resolution rather than erroring.

MusicBrainz's 1 req/sec limit and descriptive `User-Agent` are enforced as terms-of-service requirements — violating either gets the app IP-blocked for everyone. Cover Art Archive is a separate host and is not rate-limited, so its lookups fan out concurrently.

## Safety

Every image byte enters through one guarded function: 15s timeout, ≤5 redirects, ≤20MB enforced while streaming, `image/*` content-type, Pillow `verify()` before anything touches disk, `http`/`https` only. Applies to thumbnails, picked results and pasted URLs alike.

All network I/O runs on `ThreadPoolSingleton`/`Worker`; nothing blocks the UI thread.

Pasted URLs are not restricted to public addresses — the user types them into a local desktop app. Flagged as a deliberate choice rather than an oversight.

## For reviewers

Things that took a few passes and are worth a look:

- **Search generation token** — pressing Enter twice used to let a superseded search's workers inject results into the new grid and corrupt the pending-provider count.
- **Worker cancellation** — `Worker.run` emits *only* `finished` when cancelled (`DeviceManager.cancel_all_operations()` fires on eject and device disconnect). The pending count is decremented from `finished` so a cancelled search can't wedge the dialog on "Searching…".
- **Result budget** — each provider is asked for a full grid; its share is an *acceptance* cap only while another provider is outstanding. Held-back results fill the grid once all providers settle, so a query where Cover Art Archive has nothing still shows 24 covers rather than 12.
- **Grid geometry** — cards are a fixed size and the column count follows the window width. Variable-width cards meant a late result could move a card out from under the cursor mid-click.
- **Provider isolation** — one provider failing is non-fatal; the other's results still render.

## Testing

7 new test files, ~90 tests, no new dependencies (`monkeypatch` on `requests`, matching `test_podcast_network_errors.py`). No test makes a real network call.

End-to-end against the live APIs: seeding "Daft Punk Discovery" returns 11 iTunes and 6 Cover Art Archive candidates with the correct album first from both, and the download produces a 1200×1200 RGB PNG.

Verified end to end on hardware: an **iPod Classic 6th generation (80GB) on macOS** — searching, picking a cover, cropping, and syncing, with the artwork landing correctly on the device.

The repo has 4 test failures and a non-zero `scripts/dev.py arch` exit on `main` already; this branch adds no new ones (arch output is byte-identical to baseline).
