### PR TITLE
fix(macos): revalidate volumes via the kernel instead of diskutil

### DIFF
--- a/src/iopenpod/device/filesystem.py
+++ b/src/iopenpod/device/filesystem.py
@@ -12,6 +12,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from . import macos_volume
+
 logger = logging.getLogger(__name__)
 
 ITUNESDB_PLATFORM_MAC = 1
@@ -138,6 +140,11 @@ def _detect_linux_filesystem(mount_path: str) -> str:
 
 
 def _detect_macos_filesystem(mount_path: str) -> str:
+    kernel = macos_volume.read_mounted_volume(mount_path)
+    if kernel is not None:
+        value = _normalize_filesystem_type(kernel.filesystem_type)
+        if value:
+            return value
     try:
         proc = subprocess.run(
             ["diskutil", "info", "-plist", mount_path],

--- a/src/iopenpod/device/filesystem_profile.py
+++ b/src/iopenpod/device/filesystem_profile.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Protocol, cast
 
+from . import macos_volume
 from .filesystem import detect_filesystem_type
 
 _LINUX_MOUNTINFO = Path("/proc/self/mountinfo")
@@ -322,6 +323,40 @@ def _inspect_linux(requested_path: str) -> _MountedFilesystemFacts:
 
 
 def _inspect_macos(requested_path: str) -> _MountedFilesystemFacts:
+    """Describe the volume from the kernel; ask Disk Arbitration only for gaps.
+
+    ``diskutil info`` blocks behind writes already in flight to the same
+    volume, and on a slow iPod that outlasts the 5 second timeout below.  The
+    sync path revalidates before every copy, so it must not depend on it.
+    """
+    kernel = macos_volume.read_mounted_volume(requested_path)
+    if kernel is None:
+        return _inspect_macos_with_diskutil(requested_path)
+    volume_id = kernel.volume_uuid
+    errors: tuple[str, ...] = ()
+    if not volume_id:
+        # The filesystem reports no UUID; Disk Arbitration may still derive one.
+        fallback = _inspect_macos_with_diskutil(requested_path)
+        volume_id = fallback.identity.volume_id
+        errors = fallback.errors
+    return _MountedFilesystemFacts(
+        mount_path=os.path.realpath(kernel.mount_path),
+        filesystem_type=kernel.filesystem_type,
+        mount_source=kernel.device_node,
+        mount_options=kernel.mount_options,
+        read_only=kernel.read_only,
+        allocation_unit_size=_positive_int(kernel.block_size),
+        identity=VolumeIdentity(
+            operating_system="macos",
+            device_id=kernel.device_id,
+            volume_id=volume_id,
+            mount_instance=kernel.device_id,
+        ),
+        errors=errors,
+    )
+
+
+def _inspect_macos_with_diskutil(requested_path: str) -> _MountedFilesystemFacts:
     try:
         proc = subprocess.run(
             ["diskutil", "info", "-plist", requested_path],

--- a/src/iopenpod/device/macos_volume.py
+++ b/src/iopenpod/device/macos_volume.py
@@ -1,0 +1,197 @@
+"""Read mounted-volume facts on macOS straight from the kernel.
+
+``diskutil info`` asks Disk Arbitration to describe a volume, and on a slow
+external disk that request blocks until the writes already in flight settle.
+During a sync that regularly takes longer than the 5 second write-safety
+timeout, so the revalidation before a copy fails even though nothing about the
+volume changed.
+
+``statfs(2)`` and ``getattrlist(2)`` answer from the mounted filesystem's own
+state and return immediately, so callers should read the mount facts here and
+keep ``diskutil`` as a fallback for anything the kernel cannot report.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import struct
+import sys
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import cache
+
+_MNT_RDONLY = 0x00000001
+
+# Subset of <sys/mount.h> MNT_* flags spelled the way ``mount(8)`` prints them.
+_MOUNT_FLAG_NAMES: tuple[tuple[int, str], ...] = (
+    (0x00000001, "read-only"),
+    (0x00000002, "synchronous"),
+    (0x00000004, "noexec"),
+    (0x00000008, "nosuid"),
+    (0x00000010, "nodev"),
+    (0x00000020, "union"),
+    (0x00000040, "asynchronous"),
+    (0x00001000, "local"),
+    (0x00002000, "quota"),
+    (0x00004000, "rootfs"),
+    (0x00200000, "noowners"),
+    (0x00800000, "journaled"),
+    (0x01000000, "nouserxattr"),
+    (0x02000000, "defwrite"),
+    (0x08000000, "noatime"),
+)
+
+_ATTR_BIT_MAP_COUNT = 5
+_ATTR_CMN_RETURNED_ATTRS = 0x80000000
+_ATTR_VOL_INFO = 0x80000000
+_ATTR_VOL_UUID = 0x00040000
+_ATTRIBUTE_SET_SIZE = 4 * _ATTR_BIT_MAP_COUNT
+_UUID_SIZE = 16
+
+
+@dataclass(frozen=True, slots=True)
+class MacOSVolumeFacts:
+    """What the kernel reports about the mounted volume containing a path."""
+
+    mount_path: str
+    device_node: str
+    filesystem_type: str
+    read_only: bool
+    mount_options: tuple[str, ...]
+    block_size: int
+    volume_uuid: str
+
+    @property
+    def device_id(self) -> str:
+        """Return the ``diskNsM`` identifier that Disk Arbitration would report."""
+        return self.device_node.removeprefix("/dev/")
+
+
+class _Statfs(ctypes.Structure):
+    # struct statfs with 64-bit inodes (sys/mount.h, _DARWIN_FEATURE_64_BIT_INODE).
+    _fields_ = (
+        ("f_bsize", ctypes.c_uint32),
+        ("f_iosize", ctypes.c_int32),
+        ("f_blocks", ctypes.c_uint64),
+        ("f_bfree", ctypes.c_uint64),
+        ("f_bavail", ctypes.c_uint64),
+        ("f_files", ctypes.c_uint64),
+        ("f_ffree", ctypes.c_uint64),
+        ("f_fsid", ctypes.c_int32 * 2),
+        ("f_owner", ctypes.c_uint32),
+        ("f_type", ctypes.c_uint32),
+        ("f_flags", ctypes.c_uint32),
+        ("f_fssubtype", ctypes.c_uint32),
+        ("f_fstypename", ctypes.c_char * 16),
+        ("f_mntonname", ctypes.c_char * 1024),
+        ("f_mntfromname", ctypes.c_char * 1024),
+        ("f_flags_ext", ctypes.c_uint32),
+        ("f_reserved", ctypes.c_uint32 * 7),
+    )
+
+
+class _Attrlist(ctypes.Structure):
+    _fields_ = (
+        ("bitmapcount", ctypes.c_ushort),
+        ("reserved", ctypes.c_ushort),
+        ("commonattr", ctypes.c_uint32),
+        ("volattr", ctypes.c_uint32),
+        ("dirattr", ctypes.c_uint32),
+        ("fileattr", ctypes.c_uint32),
+        ("forkattr", ctypes.c_uint32),
+    )
+
+
+@cache
+def _libc() -> ctypes.CDLL | None:
+    name = ctypes.util.find_library("c")
+    if not name:
+        return None
+    try:
+        return ctypes.CDLL(name, use_errno=True)
+    except OSError:
+        return None
+
+
+def _statfs_function(libc: ctypes.CDLL) -> Callable[..., int] | None:
+    # x86_64 keeps the legacy 32-bit-inode layout under the plain symbol and
+    # exposes the layout above as ``statfs$INODE64``; arm64 only has the latter
+    # layout and exports it under the plain name.
+    for symbol in ("statfs$INODE64", "statfs"):
+        try:
+            function = getattr(libc, symbol)
+        except AttributeError:
+            continue
+        function.argtypes = (ctypes.c_char_p, ctypes.POINTER(_Statfs))
+        function.restype = ctypes.c_int
+        return function
+    return None
+
+
+def mount_flag_names(flags: int) -> tuple[str, ...]:
+    """Return the ``mount(8)`` option names set in a ``statfs`` flag word."""
+    return tuple(name for bit, name in _MOUNT_FLAG_NAMES if flags & bit)
+
+
+def read_mounted_volume(path: str | os.PathLike[str]) -> MacOSVolumeFacts | None:
+    """Return kernel-reported facts for the volume containing *path*, or ``None``."""
+    if sys.platform != "darwin":
+        return None
+    libc = _libc()
+    if libc is None:
+        return None
+    statfs = _statfs_function(libc)
+    if statfs is None:
+        return None
+
+    encoded = os.fsencode(os.fspath(path))
+    stats = _Statfs()
+    if statfs(encoded, ctypes.byref(stats)) != 0:
+        return None
+    mount_path = os.fsdecode(stats.f_mntonname)
+    device_node = os.fsdecode(stats.f_mntfromname)
+    filesystem_type = stats.f_fstypename.decode("ascii", "replace").strip().casefold()
+    if not mount_path or not device_node or not filesystem_type:
+        return None
+    return MacOSVolumeFacts(
+        mount_path=mount_path,
+        device_node=device_node,
+        filesystem_type=filesystem_type,
+        read_only=bool(stats.f_flags & _MNT_RDONLY),
+        mount_options=mount_flag_names(stats.f_flags),
+        block_size=int(stats.f_bsize),
+        volume_uuid=_volume_uuid(libc, os.fsencode(mount_path)),
+    )
+
+
+def _volume_uuid(libc: ctypes.CDLL, mount_path: bytes) -> str:
+    """Return the volume UUID as ``diskutil`` prints it, or ``""`` if unsupported."""
+    try:
+        getattrlist = libc.getattrlist
+    except AttributeError:
+        return ""
+    getattrlist.argtypes = (
+        ctypes.c_char_p,
+        ctypes.POINTER(_Attrlist),
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_uint32,
+    )
+    getattrlist.restype = ctypes.c_int
+    request = _Attrlist(
+        bitmapcount=_ATTR_BIT_MAP_COUNT,
+        commonattr=_ATTR_CMN_RETURNED_ATTRS,
+        volattr=_ATTR_VOL_INFO | _ATTR_VOL_UUID,
+    )
+    buffer = ctypes.create_string_buffer(4 + _ATTRIBUTE_SET_SIZE + _UUID_SIZE)
+    if getattrlist(mount_path, ctypes.byref(request), buffer, len(buffer), 0) != 0:
+        return ""
+    (length,) = struct.unpack_from("<I", buffer.raw, 0)
+    returned = struct.unpack_from(f"<{_ATTR_BIT_MAP_COUNT}I", buffer.raw, 4)
+    if length < len(buffer) or not returned[1] & _ATTR_VOL_UUID:
+        return ""
+    start = 4 + _ATTRIBUTE_SET_SIZE
+    return str(uuid.UUID(bytes=buffer.raw[start : start + _UUID_SIZE])).upper()

--- a/tests/test_device_filesystem.py
+++ b/tests/test_device_filesystem.py
@@ -174,6 +174,10 @@ def test_writer_logs_actual_filesystem_and_preserved_platform_mismatch(
 ) -> None:
     create_virtual_ipod(tmp_path, "MA005")
     itunes_dir = tmp_path / "iPod_Control" / "iTunes"
+    existing_db = itunes_dir / "iTunesDB"
+    existing = bytearray(existing_db.read_bytes())
+    struct.pack_into("<H", existing, 0x20, 2)
+    existing_db.write_bytes(existing)
     predictable_temps = [
         itunes_dir / "iTunesDB.tmp",
         itunes_dir / "iTunesDB.backup.tmp",

--- a/tests/test_filesystem_profile.py
+++ b/tests/test_filesystem_profile.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import os
 import plistlib
+import subprocess
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
-from iopenpod.device import filesystem_profile
+from iopenpod.device import filesystem_profile, macos_volume
 
 
 def _linux_mountinfo_line(
@@ -253,6 +255,7 @@ def test_macos_profile_uses_diskutil_volume_identity_and_format(
         return SimpleNamespace(returncode=0, stdout=plistlib.dumps(disk_info), stderr=b"")
 
     monkeypatch.setattr(filesystem_profile.sys, "platform", "darwin")
+    monkeypatch.setattr(macos_volume, "read_mounted_volume", lambda _path: None)
     monkeypatch.setattr(filesystem_profile.subprocess, "run", fake_run)
     monkeypatch.setattr(filesystem_profile.os, "pathconf", lambda *_args: 255, raising=False)
 
@@ -430,3 +433,77 @@ def test_profile_fails_closed_when_mount_identity_cannot_be_detected(
     assert profile.safe_for_writes is False
     assert profile.identity.is_complete is False
     assert any("mount table" in error.casefold() for error in profile.detection_errors)
+
+
+def _kernel_volume_facts(mount_path: Path) -> macos_volume.MacOSVolumeFacts:
+    return macos_volume.MacOSVolumeFacts(
+        mount_path=os.path.realpath(mount_path),
+        device_node="/dev/disk4s2",
+        filesystem_type="hfs",
+        read_only=False,
+        mount_options=("nosuid", "nodev", "local", "noowners", "journaled"),
+        block_size=16384,
+        volume_uuid="ED309777-33BD-3935-B36F-85F326FBB8EE",
+    )
+
+
+def _busy_diskutil(commands: list[list[str]]):
+    """Mimic ``diskutil info`` stalling behind in-flight writes to the volume."""
+
+    def fake_run(args, **kwargs):
+        commands.append(args)
+        raise subprocess.TimeoutExpired(args, kwargs.get("timeout", 5))
+
+    return fake_run
+
+
+def test_macos_revalidation_uses_kernel_volume_facts_when_diskutil_stalls(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(filesystem_profile.sys, "platform", "darwin")
+    monkeypatch.setattr(macos_volume, "read_mounted_volume", lambda _path: _kernel_volume_facts(tmp_path))
+    monkeypatch.setattr(filesystem_profile.subprocess, "run", _busy_diskutil(commands))
+    monkeypatch.setattr(filesystem_profile.os, "pathconf", lambda *_args: 255, raising=False)
+
+    retained = filesystem_profile.inspect_filesystem_profile(tmp_path, reported_volume_format="HFSPLUS")
+    result = filesystem_profile.revalidate_filesystem_profile(retained)
+
+    assert commands == []
+    assert result.safe_to_continue, result.reason
+    assert result.current_identity == filesystem_profile.VolumeIdentity(
+        operating_system="macos",
+        device_id="disk4s2",
+        volume_id="ED309777-33BD-3935-B36F-85F326FBB8EE",
+        mount_instance="disk4s2",
+    )
+    assert retained.filesystem_type == "hfs"
+    assert retained.mount_source == "/dev/disk4s2"
+    assert retained.mount_options == ("nosuid", "nodev", "local", "noowners", "journaled")
+    assert retained.allocation_unit_size == 16384
+    assert retained.safe_for_writes is True
+
+
+def test_macos_profile_asks_diskutil_only_for_a_missing_volume_uuid(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    facts = replace(_kernel_volume_facts(tmp_path), volume_uuid="")
+    disk_info = {"DeviceIdentifier": "disk4s2", "VolumeUUID": "90C5CF3C-6734-4C25-867B-AF4EE52911CC"}
+    commands: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
+        commands.append(args)
+        return SimpleNamespace(returncode=0, stdout=plistlib.dumps(disk_info), stderr=b"")
+
+    monkeypatch.setattr(filesystem_profile.sys, "platform", "darwin")
+    monkeypatch.setattr(macos_volume, "read_mounted_volume", lambda _path: facts)
+    monkeypatch.setattr(filesystem_profile.subprocess, "run", fake_run)
+    monkeypatch.setattr(filesystem_profile.os, "pathconf", lambda *_args: 255, raising=False)
+
+    profile = filesystem_profile.inspect_filesystem_profile(tmp_path)
+
+    assert len(commands) == 1
+    assert profile.filesystem_type == "hfs"
+    assert profile.identity.volume_id == "90C5CF3C-6734-4C25-867B-AF4EE52911CC"

--- a/tests/test_macos_volume.py
+++ b/tests/test_macos_volume.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+import uuid
+
+import pytest
+
+from iopenpod.device import macos_volume
+
+
+def test_mount_flag_names_match_mount_output_spelling() -> None:
+    flags = 0x00000001 | 0x00000008 | 0x00000010 | 0x00001000 | 0x00800000
+    assert macos_volume.mount_flag_names(flags) == ("read-only", "nosuid", "nodev", "local", "journaled")
+    assert macos_volume.mount_flag_names(0) == ()
+
+
+def test_device_id_strips_the_dev_prefix() -> None:
+    facts = macos_volume.MacOSVolumeFacts(
+        mount_path="/Volumes/iPod",
+        device_node="/dev/disk4s2",
+        filesystem_type="hfs",
+        read_only=False,
+        mount_options=(),
+        block_size=16384,
+        volume_uuid="",
+    )
+    assert facts.device_id == "disk4s2"
+
+
+def test_read_mounted_volume_is_none_off_macos(monkeypatch) -> None:
+    monkeypatch.setattr(macos_volume.sys, "platform", "linux")
+    assert macos_volume.read_mounted_volume("/") is None
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="reads the live root volume through statfs/getattrlist")
+def test_read_mounted_volume_describes_the_root_volume() -> None:
+    facts = macos_volume.read_mounted_volume("/")
+    assert facts is not None
+    assert facts.mount_path == "/"
+    assert facts.device_node.startswith("/dev/disk")
+    assert facts.filesystem_type == "apfs"
+    assert facts.block_size > 0
+    assert uuid.UUID(facts.volume_uuid)
+    assert macos_volume.read_mounted_volume("/definitely/not/mounted") is None


### PR DESCRIPTION
## The problem

On macOS, any sync that copies files to a slow iPod aborts partway through with:

```
filesystem_safety: The iPod volume is no longer safe to write: The mounted volume identity could not be read. iOpenPod stopped before the next write.
```

The volume is mounted, writable and unchanged the whole time.

`_inspect_macos` describes the volume by shelling out to `diskutil info -plist <mount>` with a 5 second timeout, and the sync path revalidates through it before every device write. `diskutil info` asks Disk Arbitration about the volume, and that call blocks until writes already in flight to the same volume settle. On a USB 2.0 iPod a single track copy outlasts the timeout, so the call times out, `_unavailable_facts` returns an empty `VolumeIdentity`, `identity.is_complete` is false, and the write guard aborts the sync.

Measured on an iPod Nano 3rd Gen (HFS+, `/Volumes/iPod`), with a 300 MB `dd` running against the volume:

| call | idle | during write |
| --- | --- | --- |
| `diskutil info -plist /Volumes/iPod` | 0.09 s | 6.7-7.8 s |
| `diskutil info -plist disk4` (whole disk) | 0.07 s | 0.07 s |
| `statfs` / `stat` / `df` / raw device read | instant | instant |

So it is specific to asking Disk Arbitration about a *busy volume*, not to the device being slow in general.

This arrived in 1.66.2 with `File system and OS safe read and writes`; 1.66.1 and earlier never revalidated this way and never hit it.

## The change

Read the mount facts from the kernel on the hot path, and keep `diskutil` as a fallback.

New `iopenpod/device/macos_volume.py` wraps two syscalls:

- `statfs(2)` for the device node, filesystem type, read-only flag, mount options and block size
- `getattrlist(2)` with `ATTR_VOL_UUID` for the volume UUID

Both answer from the mounted filesystem's own state and return in well under a millisecond during the same write that stalls `diskutil`, and they report identical values (`disk4s2`, `hfs`, `ED309777-…`), so the `volume_identity_key` format is unchanged and existing keys still match.

`_inspect_macos` now uses those facts, and falls back to `diskutil` when the syscalls fail or the filesystem reports no UUID. `_detect_macos_filesystem` prefers them too.

`statfs` also resolves the containing volume for any path, whereas `diskutil` only accepted mount points and answered `Could not find disk` otherwise. That makes the macOS inspector behave like the Linux and Windows ones. One existing test relied on the old behaviour leaving a virtual-iPod fixture's filesystem "unknown", so it now pins the fixture's platform flag explicitly instead of depending on that.

## Testing

- New tests: revalidation succeeds while `diskutil` stalls, the `diskutil` fallback when kernel facts are unavailable, the UUID-only fallback, and unit tests for the new module.
- Verified on hardware: built this branch with `pyinstaller iOpenPod.spec` and ran it against the iPod that had been failing. The exact sync that failed twice earlier (3 podcast episodes) completed, the database went from 0 to 3 tracks, and the log contains no `timed out after 5 seconds`, no `Unsafe iPod filesystem profile` and no `Sync stopped by device safety guard`.
- `scripts/dev.py check`: lint, types and arch pass. Tests pass apart from four failures that are already present on a clean checkout of `main` (two Linux udev tests, one playlist-dataset test, one sync-plan-merge test) and are unrelated to this change.

Only tested on Apple Silicon. The `statfs$INODE64` symbol lookup covers the Intel layout, but a second pair of eyes there would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
